### PR TITLE
Add textvariable to the calendar.

### DIFF
--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -38,6 +38,7 @@ class Calendar(ttk.Frame):
     date = calendar.datetime.date
     timedelta = calendar.datetime.timedelta
     strptime = calendar.datetime.datetime.strptime
+    strftime = calendar.datetime.datetime.strftime
 
     def __init__(self, master=None, **kw):
         """
@@ -95,7 +96,7 @@ class Calendar(ttk.Frame):
         prop = self._font.actual()
         prop["size"] += 1
         self._header_font = Font(self, **prop)
-
+        
         try:
             bd = int(kw.pop('borderwidth', 2))
         except ValueError:
@@ -103,6 +104,14 @@ class Calendar(ttk.Frame):
 
         # --- date
         today = self.date.today()
+
+        try:
+            self._textvariable = kw.pop("textvariable")
+#            if ( self._datevariable is not None ):
+#              if not ( isinstance( self._datevariable, tkinter.Variable     ) ):
+#                raise TypeError( "tkinter.Variable type expected, {} given.".format( type( self._datevariable ) ) )
+        except KeyError:
+            self._textvariable = None
 
         if (("month" in kw) or ("year" in kw)) and ("day" not in kw):
             month = kw.pop("month", today.month)
@@ -118,6 +127,9 @@ class Calendar(ttk.Frame):
                 self._sel_date = None
 
         self._date = self.date(year, month, 1)  # (year, month) displayed by the calendar
+        
+        if self._textvariable is not None:
+          self._textvariable.set(self._sel_date.strftime("%x"))
 
         # --- selectmode
         selectmode = kw.pop("selectmode", "day")
@@ -528,6 +540,8 @@ class Calendar(ttk.Frame):
             self._remove_selection()
             self._sel_date = self.date(year, month, day)
             self._display_selection()
+            if self._textvariable is not None:
+                self._textvariable.set(self._sel_date.strftime("%x"))
             self.event_generate("<<CalendarSelected>>")
 
     # --- selection handling
@@ -536,6 +550,7 @@ class Calendar(ttk.Frame):
         Return currently selected date (datetime.date instance).
         Always return None if selectmode is "none".
         """
+
         if self._properties.get("selectmode") is "day":
             return self._sel_date
         else:
@@ -566,6 +581,14 @@ class Calendar(ttk.Frame):
                 self._date = self._sel_date.replace(day=1)
                 self._display_calendar()
                 self._display_selection()
+
+    def get_date(self):
+        return self._sel_date.strftime("%x")
+
+    def set_date(self, value):
+        if ( value is not None ):
+            self.selection_set(self, value)
+            self._textvariable.set(self._sel_date.strftime("%x"))
 
     # --- other methods
     def keys(self):


### PR DESCRIPTION
Modifications proposed by Neal Probert:

> I hacked tkcalendar.py to support the textvariable option to get it's initial value and to set it when the day is clicked. Also added get_date() and set_date() methods to use when reading/writing config files. I also needed to have multiple calendars up on the same frame.

Fixes #6 