### PR TITLE
Add textvariable option to Calendar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,8 @@ Documentation
 
         selectmode: "none" or "day" (default) define whether the user can change the selected day with a mouse click
 
+        textvariable: StringVar that will contain the currently selected date as str
+
         background: calendar border and month/year name background color
 
         foreground: month/year name foreground color
@@ -130,6 +132,10 @@ Documentation
 
 Changelog
 ---------
+
+- tkcalendar 1.2.0
+
+    * Add textvariable option
 
 - tkcalendar 1.1.5
 

--- a/test.py
+++ b/test.py
@@ -133,6 +133,38 @@ class TestCalendar(BaseWidgetTest):
         l = ttk.Label(widget, text="12")
         widget._on_click(TestEvent(widget=l))
 
+    def test_calendar_textvariable(self):
+        var = tk.StringVar(self.window,)
+        widget = Calendar(self.window, selectmode='day', locale=None,
+                          year=2015, month=1, day=3, textvariable=var)
+        widget.pack()
+        self.window.update()
+        self.assertEqual(datetime(2015, 1, 3).strftime('%x'), var.get())
+        self.assertEqual(datetime(2015, 1, 3).strftime('%x'), widget.get_date())
+        widget.selection_set(datetime(2018, 11, 21))
+        self.window.update()
+        self.assertEqual(datetime(2018, 11, 21).strftime('%x'), var.get())
+        self.assertEqual(datetime(2018, 11, 21).strftime('%x'), widget.get_date())
+        widget.selection_set(None)
+        self.window.update()
+        self.assertEqual('', widget.get_date())
+        self.assertEqual('', var.get())
+        var.set(datetime(2014, 3, 2).strftime('%x'))
+        self.window.update()
+        self.assertEqual(datetime(2014, 3, 2), widget.selection_get())
+        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), var.get())
+        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), widget.get_date())
+        var.set('a')
+        self.window.update()
+        self.assertEqual(datetime(2014, 3, 2), widget.selection_get())
+        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), var.get())
+        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), widget.get_date())
+        var.set('')
+        self.window.update()
+        self.assertIsNone(widget.selection_get())
+        self.assertEqual('', var.get())
+        self.assertEqual('', widget.get_date())
+
     def test_calendar_get_set(self):
         widget = Calendar(self.window, foreground="red")
         widget.pack()
@@ -142,6 +174,7 @@ class TestCalendar(BaseWidgetTest):
                    'font',
                    'borderwidth',
                    'selectmode',
+                   'textvariable',
                    'locale',
                    'selectbackground',
                    'selectforeground',
@@ -191,10 +224,10 @@ class TestCalendar(BaseWidgetTest):
             widget.config(locale="en_US.UTF-8")
         with self.assertRaises(AttributeError):
             widget.config(test="test")
-        dic = {op: "yellow" for op in options[5:]}
+        dic = {op: "yellow" for op in options[6:]}
         widget.configure(**dic)
         self.window.update()
-        for op in options[5:]:
+        for op in options[6:]:
             self.assertEqual(widget.cget(op), "yellow")
 
 

--- a/test.py
+++ b/test.py
@@ -154,7 +154,12 @@ class TestCalendar(BaseWidgetTest):
         self.assertEqual(datetime(2014, 3, 2), widget.selection_get())
         self.assertEqual(datetime(2014, 3, 2).strftime('%x'), var.get())
         self.assertEqual(datetime(2014, 3, 2).strftime('%x'), widget.get_date())
-        var.set('a')
+        try:
+            var.set('a')
+        except tk.TclError:
+            # some versions of python raise an error because of the exception
+            # raised inside the trace
+            pass
         self.window.update()
         self.assertEqual(datetime(2014, 3, 2), widget.selection_get())
         self.assertEqual(datetime(2014, 3, 2).strftime('%x'), var.get())

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -59,7 +59,7 @@ class Calendar(ttk.Frame):
                      raise 'locale.Error: unsupported locale setting')
             selectmode: "none" or "day" (default) define whether the user
                         can change the selected day with a mouse click
-            textvariable: StringVar containing the currently selected date as str
+            textvariable: StringVar that will contain the currently selected date as str
             background: calendar border and month/year name background color
             foreground: month/year name foreground color
             bordercolor: day border color

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -2,6 +2,7 @@
 """
 tkcalendar - Calendar and DateEntry widgets for Tkinter
 Copyright 2017-2018 Juliette Monsel <j_4321@protonmail.com>
+Copyright 2018 Neal Probert (https://github.com/nprobert)
 
 tkcalendar is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Add textvariable option to Calendar: StringVar that stores the currently selected date as a string and can be used to change the date of the Calendar.