### PR TITLE
Fix #13: Error when creating DateEntry widget with python 3.6.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -153,6 +153,9 @@ Documentation
 Changelog
 ---------
 
+- tkcalendar 1.2.1
+    * Fix `ValueError` in `DateEntry` with Python 3.6.5
+
 - tkcalendar 1.2.0
 
     * Add textvariable option to Calendar
@@ -161,7 +164,7 @@ Changelog
       disableddaybackground and disableddayforeground to configure colors
       when Calendar is disabled
     * Fix DateEntry behavior in readonly mode
-    * Make Calendar.selection_get always return a datetime.date 
+    * Make Calendar.selection_get always return a datetime.date
 
 - tkcalendar 1.1.5
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='tkcalendar',
-      version='1.2.0',
+      version='1.2.1',
       description='Calendar and DateEntry widgets for Tkinter',
       long_description=long_description,
       url='https://github.com/j4321/tkcalendar',

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -835,12 +835,20 @@ class DateEntry(ttk.Entry):
         self.style.layout('DateEntry', self.style.layout('TCombobox'))
         fieldbg = self.style.map('TCombobox', 'fieldbackground')
         self.style.map('DateEntry', fieldbackground=fieldbg)
-        self.after_cancel(self._determine_bbox_after_id)
+        try:
+            self.after_cancel(self._determine_bbox_after_id)
+        except ValueError:
+            # nothing to cancel
+            pass
         self._determine_bbox_after_id = self.after(10, self._determine_bbox)
 
     def _determine_bbox(self, event=None):
         """Determine downarrow button bbox."""
-        self.after_cancel(self._determine_bbox_after_id)
+        try:
+            self.after_cancel(self._determine_bbox_after_id)
+        except ValueError:
+            # nothing to cancel
+            pass
         if self.winfo_ismapped():
             self.update_idletasks()
             h = self.winfo_height()
@@ -944,7 +952,11 @@ class DateEntry(ttk.Entry):
             self.state(('readonly',))
 
     def destroy(self):
-        self.after_cancel(self._determine_bbox_after_id)
+        try:
+            self.after_cancel(self._determine_bbox_after_id)
+        except ValueError:
+            # nothing to cancel
+            pass
         ttk.Entry.destroy(self)
 
     def drop_down(self):


### PR DESCRIPTION
Put `after_cancel` in try/except block to catch the `ValueError` which is raised since Python 3.6.5 if there is nothing to cancel.