### PR TITLE
Improve locale support

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ environment:
     - PYTHON: "C:\\PYTHON35"
     - PYTHON: "C:\\PYTHON36"
 install:
-  - "%PYTHON%\\python.exe -m pip install codecov coverage nose pillow pynput"
+  - "%PYTHON%\\python.exe -m pip install codecov coverage nose pillow pynput babel"
 build: off
 test_script:
   - "%PYTHON%\\python.exe -m pip install ."

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
   - sleep 3
 install:
   - sudo apt-get install python-tk python3-tk
-  - python -m pip install coverage codecov pillow pynput
+  - python -m pip install coverage codecov pillow pynput babel
 script:
   - python -m pip install .
   - python -m nose

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ Calendar widget
 
         **day**: initially selected day, if month or year is given but not day, no initial selection, otherwise, default is today
 
-        **locale**: locale to use, e.g. "fr_FR" for a French calendar (the locale needs to be installed, otherwise it will raise 'locale.Error: unsupported locale setting')
+        **locale**: locale to use, e.g. "fr_FR" for a French calendar
 
         **selectmode**: "none" or "day" (default) define whether the user can change the selected day with a mouse click
 
@@ -189,7 +189,6 @@ Changelog
 - tkcalendar 1.3.0
 
     * No longer set locale globally to avoid conflicts between several instances
-    * Automatically add encoding to the locale string if not given
 
 - tkcalendar 1.2.1
 

--- a/README.rst
+++ b/README.rst
@@ -135,7 +135,7 @@ Calendar widget
 
         **selection_get()**: If selectmode is 'day', returns the selected date as a ``datetime.date`` instance, otherwise returns ``None``.
 
-        **selection_set(self, date)**: If selectmode is 'day', sets the selection to *date* where *date* can be either a ```datetime.date``` instance or a string corresponding to the date format ``"%x"`` in the ``Calendar`` locale. Does nothing if selectmode is ``"none"``.
+        **selection_set(self, date)**: If selectmode is 'day', sets the selection to *date* where *date* can be either a ``datetime.date`` instance or a string corresponding to the date format ``"%x"`` in the ``Calendar`` locale. Does nothing if selectmode is ``"none"``.
 
 
 DateEntry widget
@@ -203,7 +203,7 @@ Changelog
       disableddaybackground and disableddayforeground to configure colors
       when Calendar is disabled
     * Fix DateEntry behavior in readonly mode
-    * Make Calendar.selection_get always return a datetime.date
+    * Make Calendar.selection_get always return a ``datetime.date``
 
 - tkcalendar 1.1.5
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Requirements
 ------------
 
 - Linux, Windows, Mac
-- Python 2 or 3 with tkinter + ttk (default for Windows but not for Linux)
+- Python 2 or 3 with tkinter + ttk (default for Windows but not for Linux) and babel
 
 
 Installation
@@ -61,12 +61,12 @@ Calendar widget
     * Widget-Specific Options
 
         **year**:  initially displayed year, default is current year
-        
+
         **month**: initially displayed month, default is current month
 
         **day**: initially selected day, if month or year is given but not day, no initial selection, otherwise, default is today
 
-        **locale**: locale to use, e.g. "fr_FR" for a French calendar
+        **locale**: locale to use, e.g. "fr_FR" for a French calendar (the locale needs to be installed, otherwise it will raise 'locale.Error: unsupported locale setting')
 
         **selectmode**: "none" or "day" (default) define whether the user can change the selected day with a mouse click
 
@@ -122,21 +122,21 @@ Calendar widget
         A ``<<CalendarSelected>>`` event is generated each time the user selects a day with the mouse.
 
     Widget methods:
-    
+
     * Standard methods:
-        
+
         - The methods common to all tkinter widgets (more details here: http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/universal.html)
-        
+
         - The methods common to all ttk widgets (more details here: http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/ttk-Widget.html)
-    
+
     * Widget-Specific methods:
-        
+
         **get_date()**: If selectmode is 'day', returns the string corresponding to the selected date in the ``Calendar`` locale, otherwise returns ``""``.
-        
+
         **selection_get()**: If selectmode is 'day', returns the selected date as a ``datetime.date`` instance, otherwise returns ``None``.
-            
+
         **selection_set(self, date)**: If selectmode is 'day', sets the selection to *date* where *date* can be either a ```datetime.date``` instance or a string corresponding to the date format ``"%x"`` in the ``Calendar`` locale. Does nothing if selectmode is ``"none"``.
-            
+
 
 DateEntry widget
 
@@ -162,29 +162,34 @@ DateEntry widget
     * Virtual Events
 
         A ``<<DateEntrySelected>>`` event is generated each time the user selects a date.
-        
+
     Widget methods:
-        
+
     * Standard methods:
-        
+
         - The methods common to all tkinter widgets (more details here: http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/universal.html)
-        
+
         - The methods common to all ttk widgets (more details here: http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/ttk-Widget.html)
-        
+
         - The methods of the ``Entry`` widget (more details here: http://infohost.nmt.edu/tcc/help/pubs/tkinter/web/entry.html)
-    
+
     * Widget-Specific methods:
-        
+
         **drop_down()**: Displays or withdraws the drop-down calendar depending on its current state.
-        
+
         **get_date()**: Returns the selected date as a ``datetime.date`` instance.
-            
+
         **set_date(self, date)**: Sets the value of the DateEntry to *date* where *date* can be either a ``datetime.date`` instance or a string corresponding to the date format `"%x"` in the `Calendar` locale.
 
 
 Changelog
 ---------
 
+
+- tkcalendar 1.3.0
+
+    * No longer set locale globally to avoid conflicts between several instances
+    * Automatically add encoding to the locale string if not given
 
 - tkcalendar 1.2.1
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='tkcalendar',
-      version='1.2.1',
+      version='1.3.0',
       description='Calendar and DateEntry widgets for Tkinter',
       long_description=long_description,
       url='https://github.com/j4321/tkcalendar',

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(name='tkcalendar',
                    'Programming Language :: Python :: 3.6',
                    'Operating System :: OS Independent'],
       keywords=['tkinter', 'calendar', 'date'],
+      requires=["sys", "locale", "calendar", "tkinter", "babel"],
       py_modules=["tkcalendar"])

--- a/test.py
+++ b/test.py
@@ -24,7 +24,6 @@ import unittest
 from tkcalendar import Calendar, DateEntry
 from datetime import date
 from babel.dates import format_date
-import locale
 try:
     import Tkinter as tk
     import ttk
@@ -32,8 +31,6 @@ except ImportError:
     import tkinter as tk
     from tkinter import ttk
 from pynput.mouse import Controller, Button
-
-locale.setlocale(locale.LC_ALL, '')
 
 
 class BaseWidgetTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -23,9 +23,7 @@ Test
 import unittest
 from tkcalendar import Calendar, DateEntry
 from datetime import date
-from babel.dates import format_date, parse_date
-import locale
-from sys import platform
+from babel.dates import format_date
 try:
     import Tkinter as tk
     import ttk
@@ -33,8 +31,6 @@ except ImportError:
     import tkinter as tk
     from tkinter import ttk
 from pynput.mouse import Controller, Button
-
-locale.setlocale(locale.LC_ALL, '')
 
 
 class BaseWidgetTest(unittest.TestCase):
@@ -61,8 +57,6 @@ class TestEvent:
 
 class TestCalendar(BaseWidgetTest):
     def test_calendar_init(self):
-        if platform != 'linux':
-            raise ValueError(str(locale.getdefaultlocale()))
         widget = Calendar(self.window)
         widget.pack()
         self.window.update()

--- a/test.py
+++ b/test.py
@@ -24,6 +24,7 @@ import unittest
 from tkcalendar import Calendar, DateEntry
 from datetime import date
 from babel.dates import format_date
+import locale
 try:
     import Tkinter as tk
     import ttk
@@ -31,6 +32,8 @@ except ImportError:
     import tkinter as tk
     from tkinter import ttk
 from pynput.mouse import Controller, Button
+
+locale.setlocale(locale.LC_ALL, '')
 
 
 class BaseWidgetTest(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -22,7 +22,8 @@ Test
 
 import unittest
 from tkcalendar import Calendar, DateEntry
-from datetime import datetime, date
+from datetime import date
+from babel.dates import format_date, parse_date
 import locale
 try:
     import Tkinter as tk
@@ -118,7 +119,7 @@ class TestCalendar(BaseWidgetTest):
         widget._prev_year()
         widget._next_year()
         widget._remove_selection()
-        widget.selection_set(datetime(2018, 12, 31).strftime('%x'))
+        widget.selection_set(format_date(date(2018, 12, 31), 'short'))
         self.assertEqual(widget.selection_get(), date(2018, 12, 31))
         with self.assertRaises(ValueError):
             widget.selection_set("ab")
@@ -150,21 +151,21 @@ class TestCalendar(BaseWidgetTest):
                           year=2015, month=1, day=3, textvariable=var)
         widget.pack()
         self.window.update()
-        self.assertEqual(date(2015, 1, 3).strftime('%x'), var.get())
-        self.assertEqual(date(2015, 1, 3).strftime('%x'), widget.get_date())
+        self.assertEqual(format_date(date(2015, 1, 3), 'short'), var.get())
+        self.assertEqual(format_date(date(2015, 1, 3), 'short'), widget.get_date())
         widget.selection_set(date(2018, 11, 21))
         self.window.update()
-        self.assertEqual(date(2018, 11, 21).strftime('%x'), var.get())
-        self.assertEqual(date(2018, 11, 21).strftime('%x'), widget.get_date())
+        self.assertEqual(format_date(date(2018, 11, 21), 'short'), var.get())
+        self.assertEqual(format_date(date(2018, 11, 21), 'short'), widget.get_date())
         widget.selection_set(None)
         self.window.update()
         self.assertEqual('', widget.get_date())
         self.assertEqual('', var.get())
-        var.set(datetime(2014, 3, 2).strftime('%x'))
+        var.set(format_date(date(2014, 3, 2), 'short'))
         self.window.update()
         self.assertEqual(date(2014, 3, 2), widget.selection_get())
-        self.assertEqual(date(2014, 3, 2).strftime('%x'), var.get())
-        self.assertEqual(date(2014, 3, 2).strftime('%x'), widget.get_date())
+        self.assertEqual(format_date(date(2014, 3, 2), 'short'), var.get())
+        self.assertEqual(format_date(date(2014, 3, 2), 'short'), widget.get_date())
         try:
             var.set('a')
         except tk.TclError:
@@ -173,8 +174,8 @@ class TestCalendar(BaseWidgetTest):
             pass
         self.window.update()
         self.assertEqual(date(2014, 3, 2), widget.selection_get())
-        self.assertEqual(date(2014, 3, 2).strftime('%x'), var.get())
-        self.assertEqual(date(2014, 3, 2).strftime('%x'), widget.get_date())
+        self.assertEqual(format_date(date(2014, 3, 2), 'short'), var.get())
+        self.assertEqual(format_date(date(2014, 3, 2), 'short'), widget.get_date())
         var.set('')
         self.window.update()
         self.assertIsNone(widget.selection_get())
@@ -326,13 +327,13 @@ class TestDateEntry(BaseWidgetTest):
         widget.pack()
         self.window.update()
 
-        widget.set_date(datetime(2018, 12, 31).strftime('%x'))
+        widget.set_date(format_date(date(2018, 12, 31), 'short'))
         self.assertEqual(widget.get_date(), date(2018, 12, 31))
         with self.assertRaises(ValueError):
             widget.set_date("ab")
-        widget.set_date(datetime(2015, 12, 31))
+        widget.set_date(date(2015, 12, 31))
         self.assertEqual(widget.get_date(), date(2015, 12, 31))
-        self.assertEqual(widget.get(), datetime(2015, 12, 31).strftime("%x"))
+        self.assertEqual(widget.get(), format_date(date(2015, 12, 31), 'short'))
 
         widget.delete(0, "end")
         widget.insert(0, "abc")

--- a/test.py
+++ b/test.py
@@ -25,6 +25,7 @@ from tkcalendar import Calendar, DateEntry
 from datetime import date
 from babel.dates import format_date, parse_date
 import locale
+from sys import platform
 try:
     import Tkinter as tk
     import ttk
@@ -60,6 +61,8 @@ class TestEvent:
 
 class TestCalendar(BaseWidgetTest):
     def test_calendar_init(self):
+        if platform != 'linux':
+            raise ValueError("%s" % locale.getdefaultlocale())
         widget = Calendar(self.window)
         widget.pack()
         self.window.update()

--- a/test.py
+++ b/test.py
@@ -95,7 +95,7 @@ class TestCalendar(BaseWidgetTest):
         self.window.update()
         widget.destroy()
 
-        widget = Calendar(self.window, selectmode='none', locale=None,
+        widget = Calendar(self.window, selectmode='none',
                           year=2015, month=1, background="black",
                           foreground="white", key="a")
         widget.pack()
@@ -145,26 +145,26 @@ class TestCalendar(BaseWidgetTest):
         self.assertEqual(widget.selection_get(), date(2015, 12, 12))
 
     def test_calendar_textvariable(self):
-        var = tk.StringVar(self.window,)
-        widget = Calendar(self.window, selectmode='day', locale=None,
+        var = tk.StringVar(self.window)
+        widget = Calendar(self.window, selectmode='day',
                           year=2015, month=1, day=3, textvariable=var)
         widget.pack()
         self.window.update()
-        self.assertEqual(datetime(2015, 1, 3).strftime('%x'), var.get())
-        self.assertEqual(datetime(2015, 1, 3).strftime('%x'), widget.get_date())
-        widget.selection_set(datetime(2018, 11, 21))
+        self.assertEqual(date(2015, 1, 3).strftime('%x'), var.get())
+        self.assertEqual(date(2015, 1, 3).strftime('%x'), widget.get_date())
+        widget.selection_set(date(2018, 11, 21))
         self.window.update()
-        self.assertEqual(datetime(2018, 11, 21).strftime('%x'), var.get())
-        self.assertEqual(datetime(2018, 11, 21).strftime('%x'), widget.get_date())
+        self.assertEqual(date(2018, 11, 21).strftime('%x'), var.get())
+        self.assertEqual(date(2018, 11, 21).strftime('%x'), widget.get_date())
         widget.selection_set(None)
         self.window.update()
         self.assertEqual('', widget.get_date())
         self.assertEqual('', var.get())
         var.set(datetime(2014, 3, 2).strftime('%x'))
         self.window.update()
-        self.assertEqual(datetime(2014, 3, 2), widget.selection_get())
-        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), var.get())
-        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), widget.get_date())
+        self.assertEqual(date(2014, 3, 2), widget.selection_get())
+        self.assertEqual(date(2014, 3, 2).strftime('%x'), var.get())
+        self.assertEqual(date(2014, 3, 2).strftime('%x'), widget.get_date())
         try:
             var.set('a')
         except tk.TclError:
@@ -172,9 +172,9 @@ class TestCalendar(BaseWidgetTest):
             # raised inside the trace
             pass
         self.window.update()
-        self.assertEqual(datetime(2014, 3, 2), widget.selection_get())
-        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), var.get())
-        self.assertEqual(datetime(2014, 3, 2).strftime('%x'), widget.get_date())
+        self.assertEqual(date(2014, 3, 2), widget.selection_get())
+        self.assertEqual(date(2014, 3, 2).strftime('%x'), var.get())
+        self.assertEqual(date(2014, 3, 2).strftime('%x'), widget.get_date())
         var.set('')
         self.window.update()
         self.assertIsNone(widget.selection_get())

--- a/test.py
+++ b/test.py
@@ -62,7 +62,7 @@ class TestEvent:
 class TestCalendar(BaseWidgetTest):
     def test_calendar_init(self):
         if platform != 'linux':
-            raise ValueError("%s" % locale.getdefaultlocale())
+            raise ValueError(str(locale.getdefaultlocale()))
         widget = Calendar(self.window)
         widget.pack()
         self.window.update()

--- a/test.py
+++ b/test.py
@@ -23,7 +23,7 @@ Test
 import unittest
 from tkcalendar import Calendar, DateEntry
 from datetime import date
-from babel.dates import format_date
+import babel.dates
 try:
     import Tkinter as tk
     import ttk
@@ -31,6 +31,11 @@ except ImportError:
     import tkinter as tk
     from tkinter import ttk
 from pynput.mouse import Controller, Button
+from locale import getdefaultlocale
+
+
+def format_date(date, length):
+    return babel.dates.format_date(date, length, locale=getdefaultlocale()[0])
 
 
 class BaseWidgetTest(unittest.TestCase):

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 tkcalendar module providing Calendar and DateEntry widgets
 """
 # TODO: custom first week day?
-# TODO: check locale in windows
+# TODO: fix locale in windows
 
 
 import calendar

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -120,15 +120,15 @@ class Calendar(ttk.Frame):
             raise ValueError('expected integer for the borderwidth option.')
 
         # --- locale
-        locale = kw.pop("locale", '.'.join(getdefaultlocale()))  # to check in windows
+        locale = kw.pop("locale", None)
         # add encoding if missing
-        if len(locale.split('.')) < 2:
+        if locale is not None and len(locale.split('.')) < 2:
             locale = '.'.join((locale, getpreferredencoding()))
 
-#        if locale is None:
-#            self._cal = calendar.TextCalendar(calendar.MONDAY)
-#        else:
-        self._cal = calendar.LocaleTextCalendar(calendar.MONDAY, locale)
+        if locale is None:
+            self._cal = calendar.TextCalendar(calendar.MONDAY)
+        else:
+            self._cal = calendar.LocaleTextCalendar(calendar.MONDAY, locale)
 
         # --- date
         today = self.date.today()
@@ -144,7 +144,10 @@ class Calendar(ttk.Frame):
             try:
                 self._sel_date = self.date(year, month, day)  # selected day
                 if self._textvariable is not None:
-                    self._textvariable.set(format_date(self._sel_date, 'short', locale))
+                    if locale is not None:
+                        self._textvariable.set(format_date(self._sel_date, 'short', locale))
+                    else:
+                        self._textvariable.set(format_date(self._sel_date, 'short'))
             except ValueError:
                 self._sel_date = None
 
@@ -648,11 +651,19 @@ class Calendar(ttk.Frame):
 
     def format_date(self, date=None):
         """Convert date (datetime.date) to a string in the locale (short format)."""
-        return format_date(date, 'short', self._properties['locale'])
+        locale = self._properties['locale']
+        if locale is None:
+            return format_date(date, 'short')
+        else:
+            return format_date(date, 'short', locale)
 
     def parse_date(self, date):
         """Parse string date in the locale format and return the corresponding datetime.date."""
-        return parse_date(date, self._properties['locale'])
+        locale = self._properties['locale']
+        if locale is None:
+            return parse_date(date)
+        else:
+            return parse_date(date, locale)
 
     # --- selection handling
     def selection_get(self):

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -117,12 +117,12 @@ class Calendar(ttk.Frame):
         except ValueError:
             raise ValueError('expected integer for the borderwidth option.')
 
+        self._cal = calendar.TextCalendar(calendar.MONDAY)
+
         # --- locale
         locale = kw.pop("locale", getdefaultlocale()[0])
         self._day_names = get_day_names('abbreviated', locale=locale)
         self._month_names = get_month_names('wide', locale=locale)
-
-        self._cal = calendar.TextCalendar(calendar.MONDAY)
 
         # --- date
         today = self.date.today()
@@ -138,10 +138,7 @@ class Calendar(ttk.Frame):
             try:
                 self._sel_date = self.date(year, month, day)  # selected day
                 if self._textvariable is not None:
-                    if locale is not None:
-                        self._textvariable.set(format_date(self._sel_date, 'short', locale))
-                    else:
-                        self._textvariable.set(format_date(self._sel_date, 'short'))
+                    self._textvariable.set(format_date(self._sel_date, 'short', locale))
             except ValueError:
                 self._sel_date = None
 
@@ -153,13 +150,6 @@ class Calendar(ttk.Frame):
             raise ValueError("'selectmode' option should be 'none' or 'day'.")
         # --- show week numbers
         showweeknumbers = kw.pop('showweeknumbers', True)
-        # --- locale
-        locale = kw.pop("locale", None)
-
-        if locale is None:
-            self._cal = calendar.TextCalendar(calendar.MONDAY)
-        else:
-            self._cal = calendar.LocaleTextCalendar(calendar.MONDAY, locale)
 
         # --- style
         self.style = ttk.Style(self)
@@ -666,19 +656,11 @@ class Calendar(ttk.Frame):
 
     def format_date(self, date=None):
         """Convert date (datetime.date) to a string in the locale (short format)."""
-        locale = self._properties['locale']
-        if locale is None:
-            return format_date(date, 'short')
-        else:
-            return format_date(date, 'short', locale)
+        return format_date(date, 'short', self._properties['locale'])
 
     def parse_date(self, date):
         """Parse string date in the locale format and return the corresponding datetime.date."""
-        locale = self._properties['locale']
-        if locale is None:
-            return parse_date(date)
-        else:
-            return parse_date(date, locale)
+        return parse_date(date, self._properties['locale'])
 
     # --- selection handling
     def selection_get(self):
@@ -1116,7 +1098,7 @@ if __name__ == "__main__":
 
         ttk.Label(top, text='Choose date').pack(padx=10, pady=10)
 
-        cal = DateEntry(top, width=12, background='darkblue', locale='fr_FR',
+        cal = DateEntry(top, width=12, background='darkblue',
                         foreground='white', borderwidth=2, year=2010)
         cal.pack(padx=10, pady=10)
 

--- a/tkcalendar.py
+++ b/tkcalendar.py
@@ -60,8 +60,6 @@ class Calendar(ttk.Frame):
             day: initially selected day, if month or year is given but not
                 day, no initial selection, otherwise, default is today
             locale: locale to use, e.g. 'fr_FR'
-                    (the locale needs to be installed, otherwise it will
-                     raise 'locale.Error: unsupported locale setting')
             selectmode: "none" or "day" (default) define whether the user
                         can change the selected day with a mouse click
             textvariable: StringVar that will contain the currently selected date as str
@@ -1097,7 +1095,7 @@ if __name__ == "__main__":
 
         ttk.Label(top, text='Choose date').pack(padx=10, pady=10)
 
-        cal = DateEntry(top, width=12, background='darkblue', locale='de_DE',
+        cal = DateEntry(top, width=12, background='darkblue', locale='fr_FR',
                         foreground='white', borderwidth=2, year=2010)
         cal.pack(padx=10, pady=10)
 


### PR DESCRIPTION
Drop use of `locale.setlocale` to avoid interferences with other instances. Use `babel` module instead. The `locale` option no longer requires the locale to be installed or to specify the encoding, e.g. 'fr_FR' for French, 'en_US' for American English or 'pt_BR' for Brazilian Portuguese.

Should fix #15.