### PR TITLE
Fix bug in DateEntry when passing style as argument

### DIFF
--- a/tests/test_dateentry.py
+++ b/tests/test_dateentry.py
@@ -11,7 +11,8 @@ from pynput.mouse import Controller
 class TestDateEntry(BaseWidgetTest):
     def test_dateentry_init(self):
         widget = DateEntry(self.window, width=12, background='darkblue',
-                           foreground='white', borderwidth=2)
+                           foreground='white', borderwidth=2, justify='center',
+                           style='my.DateEntry')
         widget.pack()
         self.window.update()
         widget.destroy()

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -74,6 +74,8 @@ class DateEntry(ttk.Entry):
         kw['selectmode'] = 'day'
         entry_kw = {}
 
+        style = kw.pop('style', 'DateEntry')
+
         for key in self.entry_kw:
             entry_kw[key] = kw.pop(key, self.entry_kw[key])
         entry_kw['font'] = kw.get('font', None)
@@ -98,7 +100,7 @@ class DateEntry(ttk.Entry):
         # style
         self.style = ttk.Style(self)
         self._setup_style()
-        self.configure(style='DateEntry')
+        self.configure(style=style)
 
         # add validation to Entry so that only date in the locale '%x' format
         # are accepted


### PR DESCRIPTION
`` DateEntry(.., style='my.DateEntry')`` triggered an exception because the ``DateEntry`` layout was not defined yet. This issue is fixed by delaying the configuration of the style.