### PR TITLE
Date limit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -356,7 +356,7 @@ Changelog
     * Add *disabledforeground* and *disabledbackground* options to further customize
       the disabled state appearance of the Calendar
     * Add *maxdate* and *mindate* options to set an allowed date range for date selection
-    * Add Calendar.see() method to make sure a date is visible
+    * Add ``Calendar.see()`` method to make sure a date is visible
 
 - tkcalendar 1.4.0
 

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,12 @@ Widget keyword options
     firstweekday : "monday" or "sunday"
         first day of the week
 
+    mindate : datetime.date or datetime.datetime (default is None)
+        minimum allowed date
+
+    maxdate : datetime.date or datetime.datetime (default is None)
+        maximum allowed date
+
     showweeknumbers : bool (default is True)
         whether to display week numbers.
 
@@ -109,6 +115,12 @@ Widget keyword options
 
     foreground :
         foreground color of month/year name
+
+    disabledbackground : str
+        background color of calendar border and month/year name in disabled state
+
+    disabledforeground : str
+        foreground color of month/year name in disabled state
 
     bordercolor :
         day border color
@@ -339,6 +351,13 @@ Widget methods
 Changelog
 =========
 
+- tkcalendar 1.5.0
+
+    * Add *disabledforeground* and *disabledbackground* options to further customize
+      the disabled state appearance of the Calendar
+    * Add *maxdate* and *mindate* options to set an allowed date range for date selection
+    * Add Calendar.see() method to make sure a date is visible
+
 - tkcalendar 1.4.0
 
     * Add ``<<CalendarMonthChanged>>`` virtual event to the Calendar widget
@@ -353,8 +372,8 @@ Changelog
 - tkcalendar 1.3.0
 
     * No longer set locale globally to avoid conflicts between several instances, use babel module instead
-    * Add option showwekknumbers to show/hide week numbers
-    * Add option firstweekday to choose first week day between 'monday' and 'sunday'
+    * Add option *showwekknumbers* to show/hide week numbers
+    * Add option *firstweekday* to choose first week day between 'monday' and 'sunday'
     * Make DateEntry compatible with more ttk themes, especially OSX default theme
     * Add possibility to display special events (like birthdays, ..) in the calendar.
       The events are displayed with colors defined by tags and the event description is displayed in a tooltip
@@ -368,11 +387,11 @@ Changelog
 
     * Add textvariable option to Calendar
     * Add state ('normal' or 'disabled') option to Calendar
-    * Add options disabledselectbackground, disabledselectforeground,
-      disableddaybackground and disableddayforeground to configure colors
+    * Add options *disabledselectbackground*, *disabledselectforeground*,
+      *disableddaybackground* and *disableddayforeground* to configure colors
       when Calendar is disabled
     * Fix DateEntry behavior in readonly mode
-    * Make Calendar.selection_get always return a ``datetime.date``
+    * Make Calendar.selection_get() always return a ``datetime.date``
 
 - tkcalendar 1.1.5
 

--- a/README.rst
+++ b/README.rst
@@ -357,6 +357,7 @@ Changelog
       the disabled state appearance of the Calendar
     * Add *maxdate* and *mindate* options to set an allowed date range for date selection
     * Add ``Calendar.see()`` method to make sure a date is visible
+    * Make ``Calendar.selection_clear()`` actually clear the selection
 
 - tkcalendar 1.4.0
 
@@ -449,6 +450,7 @@ Example
 
 .. code:: python
 
+    from tkcalendar import Calendar, DateEntry
     try:
         import tkinter as tk
         from tkinter import ttk
@@ -456,17 +458,24 @@ Example
         import Tkinter as tk
         import ttk
 
-    from tkcalendar import Calendar, DateEntry
 
     def example1():
         def print_sel():
             print(cal.selection_get())
+            cal.see(datetime.date(year=2016, month=2, day=5))
 
         top = tk.Toplevel(root)
 
-        cal = Calendar(top, font="Arial 14", selectmode='day', locale='en_US',
-                       cursor="hand1", year=2018, month=2, day=5)
+        import datetime
+        today = datetime.date.today()
 
+        mindate = datetime.date(year=2018, month=1, day=21)
+        maxdate = today + datetime.timedelta(days=5)
+        print(mindate, maxdate)
+
+        cal = Calendar(top, font="Arial 14", selectmode='day', locale='en_US',
+                       mindate=mindate, maxdate=maxdate, disabledforeground='red',
+                       cursor="hand1", year=2018, month=2, day=5)
         cal.pack(fill="both", expand=True)
         ttk.Button(top, text="ok", command=print_sel).pack()
 
@@ -504,6 +513,7 @@ Example
     ttk.Button(root, text='DateEntry', command=example3).pack(padx=10, pady=10)
 
     root.mainloop()
+
 
 
 .. |Release| image:: https://badge.fury.io/py/tkcalendar.svg

--- a/docs/Calendar.rst
+++ b/docs/Calendar.rst
@@ -10,7 +10,7 @@ Class
 
 .. autoclass:: tkcalendar.Calendar
     :show-inheritance:
-    :members: calevent_cget, calevent_configure, calevent_create, calevent_lower, calevent_raise, calevent_remove, format_date, get_calevents, get_date, keys, selection_get, selection_set, tag_cget, tag_config, tag_delete, tag_names, get_displayed_month
+    :members: calevent_cget, calevent_configure, calevent_create, calevent_lower, calevent_raise, calevent_remove, format_date, get_calevents, get_date, keys, selection_get, selection_set, tag_cget, tag_config, tag_delete, tag_names, get_displayed_month, see
 
     .. py:method:: __init__(master=None, **kw)
 

--- a/docs/Calendar.rst
+++ b/docs/Calendar.rst
@@ -21,7 +21,7 @@ Class
        cursor : str
            cursor to display when the pointer is in the widget
 
-       font : str or Tkinter Font instance
+       font : str or Tkinter Font
            font of the calendar
 
        borderwidth : int
@@ -44,6 +44,12 @@ Class
        firstweekday : str
           first day of the week: "monday" or "sunday"
 
+       mindate : datetime.date or datetime.datetime (default is None)
+            minimum allowed date
+
+       maxdate : datetime.date or datetime.datetime (default is None)
+            maximum allowed date
+
        showweeknumbers : bool
           whether to display week numbers (default is True).
 
@@ -65,7 +71,13 @@ Class
           background color of calendar border and month/year name
 
        foreground : str
-          foreground color of month/year name
+          foreground color of month/year name 
+
+       disabledbackground : str
+          background color of calendar border and month/year name in disabled state
+
+       disabledforeground : str
+          foreground color of month/year name in disabled state
 
        bordercolor : str
           day border color

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,9 +13,14 @@ tkcalendar 1.5.0
   
 - *maxdate* and *mindate*: set an allowed date range for date selection
 
-.. rubric:: New feature
+.. rubric:: New features
 
-* :meth:`Calendar.see` method: make sure given date is visible
+- :meth:`Calendar.see` method: make sure given date is visible
+
+.. rubric:: Bug fixes
+
+- Make :meth:`Calendar.selection_clear` actually clear the selection
+
 
 tkcalendar 1.4.0
 ----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,20 @@ Changelog
 
 .. currentmodule:: tkcalendar
 
+tkcalendar 1.5.0
+----------------
+
+.. rubric:: New Calendar options
+
+- *disabledforeground* and *disabledbackground*: colors of calendar border and
+  month/year name in disabled state
+  
+- *maxdate* and *mindate*: set an allowed date range for date selection
+
+.. rubric:: New feature
+
+* :meth:`Calendar.see` method: make sure given date is visible
+
 tkcalendar 1.4.0
 ----------------
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -22,7 +22,7 @@ Test
 
 from tests import BaseWidgetTest, TestEvent, tk, ttk, format_date
 from tkcalendar import Calendar
-from datetime import date
+from datetime import date, datetime
 
 
 class TestCalendar(BaseWidgetTest):
@@ -181,6 +181,8 @@ class TestCalendar(BaseWidgetTest):
                    'selectmode',
                    'textvariable',
                    'locale',
+                   'mindate',
+                   'maxdate',
                    'firstweekday',
                    'showweeknumbers',
                    'showothermonthdays',
@@ -193,6 +195,8 @@ class TestCalendar(BaseWidgetTest):
                    'background',
                    'foreground',
                    'bordercolor',
+                   'disabledbackground',
+                   'disabledforeground',
                    'othermonthforeground',
                    'othermonthbackground',
                    'othermonthweforeground',
@@ -247,6 +251,49 @@ class TestCalendar(BaseWidgetTest):
         self.assertEqual(widget["firstweekday"], 'sunday')
         with self.assertRaises(ValueError):
             widget.config(firstweekday="a")
+
+        widget["mindate"] = datetime(2018, 9, 10)
+        self.assertEqual(widget["mindate"], date(2018, 9, 10))
+        widget.selection_set(date(2018, 9, 23))
+        self.window.update()
+        i, j = widget._get_day_coords(date(2018, 9, 2))
+        self.assertIn('disabled', widget._calendar[i][j].state())
+        i, j = widget._get_day_coords(date(2018, 9, 21))
+        self.assertNotIn('disabled', widget._calendar[i][j].state())
+        self.assertIn('disabled', widget._l_month.state())
+        self.assertIn('disabled', widget._l_year.state())
+        with self.assertRaises(TypeError):
+            widget.config(mindate="a")
+        self.assertEqual(widget["mindate"], date(2018, 9, 10))
+        widget["mindate"] = None
+        self.window.update()
+        self.assertIsNone(widget["mindate"])
+        i, j = widget._get_day_coords(date(2018, 9, 2))
+        self.assertNotIn('disabled', widget._calendar[i][j].state())
+        self.assertNotIn('disabled', widget._l_month.state())
+        self.assertNotIn('disabled', widget._l_year.state())
+
+        widget["maxdate"] = datetime(2018, 9, 10)
+        self.assertEqual(widget["maxdate"], date(2018, 9, 10))
+        widget.selection_set(date(2018, 9, 2))
+        self.window.update()
+        i, j = widget._get_day_coords(date(2018, 9, 22))
+        self.assertIn('disabled', widget._calendar[i][j].state())
+        i, j = widget._get_day_coords(date(2018, 9, 4))
+        self.assertNotIn('disabled', widget._calendar[i][j].state())
+        self.assertIn('disabled', widget._r_month.state())
+        self.assertIn('disabled', widget._r_year.state())
+        with self.assertRaises(TypeError):
+            widget.config(maxdate="a")
+        self.assertEqual(widget["maxdate"], date(2018, 9, 10))
+        widget["maxdate"] = None
+        self.window.update()
+        self.assertIsNone(widget["maxdate"])
+        i, j = widget._get_day_coords(date(2018, 9, 22))
+        self.assertNotIn('disabled', widget._calendar[i][j].state())
+        self.assertNotIn('disabled', widget._r_month.state())
+        self.assertNotIn('disabled', widget._r_year.state())
+
         widget.config(selectmode="none")
         self.window.update()
         self.assertEqual(widget["selectmode"], "none")
@@ -262,10 +309,10 @@ class TestCalendar(BaseWidgetTest):
             widget.config(locale="en_US.UTF-8")
         with self.assertRaises(AttributeError):
             widget.config(test="test")
-        dic = {op: "yellow" for op in options[8:-4]}
+        dic = {op: "yellow" for op in options[12:-4]}
         widget.configure(**dic)
         self.window.update()
-        for op in options[8:-4]:
+        for op in options[12:-4]:
             self.assertEqual(widget.cget(op), "yellow")
         widget.config(tooltipalpha=0.5)
         self.assertEqual(widget["tooltipalpha"], 0.5)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -70,6 +70,30 @@ class TestCalendar(BaseWidgetTest):
             self.window.update()
             widget.destroy()
 
+        with self.assertRaises(TypeError):
+            widget = Calendar(self.window, maxdate="e")
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        widget = Calendar(self.window, mindate=datetime(2013, 5, 22, 10, 5),
+                          maxdate=datetime.today())
+        widget.pack()
+        self.window.update()
+        widget.destroy()
+
+        with self.assertRaises(TypeError):
+            widget = Calendar(self.window, mindate="e")
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(ValueError):
+            widget = Calendar(self.window, firstweekday="e")
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
         widget = Calendar(self.window, font="Arial 14", selectmode='day',
                           cursor="hand1", year=2018, month=2, day=5)
         widget.pack()
@@ -124,6 +148,11 @@ class TestCalendar(BaseWidgetTest):
         widget._on_click(TestEvent(widget=l))
         self.window.update()
         self.assertEqual(widget.selection_get(), date(2015, 12, 12))
+        widget.config(state='normal')
+        self.assertEqual(widget._date, date(2015, 12, 1))
+        widget.see(date(2017, 3, 11))
+        self.window.update()
+        self.assertEqual(widget._date, date(2017, 3, 1))
 
     def test_calendar_textvariable(self):
         var = tk.StringVar(self.window)

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -89,6 +89,13 @@ class TestCalendar(BaseWidgetTest):
             widget.destroy()
 
         with self.assertRaises(ValueError):
+            widget = Calendar(self.window, mindate=date(2018, 4, 5),
+                              maxdate=date(2018, 4, 4))
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(ValueError):
             widget = Calendar(self.window, firstweekday="e")
             widget.pack()
             self.window.update()
@@ -114,6 +121,31 @@ class TestCalendar(BaseWidgetTest):
             widget.pack()
             self.window.update()
             widget.destroy()
+
+    def test_calendar_selection(self):
+        widget = Calendar(self.window, month=3, year=2011, day=10,
+                          maxdate=date(2013, 1, 1), mindate=date(2010, 1, 1))
+        widget.pack()
+        self.assertEqual(widget.selection_get(), date(2011, 3, 10))
+
+        widget.selection_set(date(2012, 4, 11))
+        self.assertEqual(widget.selection_get(), date(2012, 4, 11))
+        self.assertEqual(widget._date, date(2012, 4, 1))
+        widget.selection_set(datetime(2012, 5, 11))
+        self.assertEqual(widget.selection_get(), date(2012, 5, 11))
+        self.assertNotIsInstance(widget.selection_get(), datetime)
+        self.assertIsInstance(widget.selection_get(), date)
+        widget.selection_set(datetime(2012, 5, 21).strftime('%x'))
+        self.assertEqual(widget.selection_get(), date(2012, 5, 21))
+        self.assertNotIsInstance(widget.selection_get(), datetime)
+        self.assertIsInstance(widget.selection_get(), date)
+
+        widget.selection_set(date(2018, 4, 11))
+        self.assertEqual(widget.selection_get(), date(2013, 1, 1))
+        widget.selection_set(date(2001, 4, 11))
+        self.assertEqual(widget.selection_get(), date(2010, 1, 1))
+        widget.selection_clear()
+        self.assertIsNone(widget.selection_get())
 
     def test_calendar_buttons_functions(self):
         widget = Calendar(self.window)

--- a/tkcalendar/__main__.py
+++ b/tkcalendar/__main__.py
@@ -10,7 +10,7 @@ except ImportError:
 def example1():
     def print_sel():
         print(cal.selection_get())
-        cal['mindate'] = datetime.date(year=2017, month=1, day=21)
+        cal.see(datetime.date(year=2016, month=2, day=5))
 
     top = tk.Toplevel(root)
 

--- a/tkcalendar/__main__.py
+++ b/tkcalendar/__main__.py
@@ -10,12 +10,20 @@ except ImportError:
 def example1():
     def print_sel():
         print(cal.selection_get())
+        cal['mindate'] = datetime.date(year=2017, month=1, day=21)
 
     top = tk.Toplevel(root)
 
-    cal = Calendar(top, font="Arial 14", selectmode='day', locale='en_US',
-                   cursor="hand1", year=2018, month=2, day=5)
+    import datetime
+    today = datetime.date.today()
 
+    mindate = datetime.date(year=2018, month=1, day=21)
+    maxdate = today + datetime.timedelta(days=5)
+    print(mindate, maxdate)
+
+    cal = Calendar(top, font="Arial 14", selectmode='day', locale='en_US',
+                   mindate=mindate, maxdate=maxdate, disabledforeground='red',
+                   cursor="hand1", year=2018, month=2, day=5)
     cal.pack(fill="both", expand=True)
     ttk.Button(top, text="ok", command=print_sel).pack()
 

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -25,15 +25,17 @@ Calendar widget
 
 
 import calendar
-from babel.dates import format_date, parse_date, get_day_names, get_month_names
+from locale import getdefaultlocale
 try:
     from tkinter import ttk
     from tkinter.font import Font
 except ImportError:
     import ttk
     from tkFont import Font
+
+from babel.dates import format_date, parse_date, get_day_names, get_month_names
+
 from tkcalendar.tooltip import TooltipWrapper
-from locale import getdefaultlocale
 
 
 class Calendar(ttk.Frame):
@@ -441,7 +443,7 @@ class Calendar(ttk.Frame):
                                   font=self._font, anchor="center")
                 self._calendar[-1].append(label)
                 label.grid(row=i, column=j, padx=(0, 1), pady=(0, 1), sticky="nsew")
-                if selectmode is "day":
+                if selectmode == "day":
                     label.bind("<1>", self._on_click)
 
         # --- *-- pack main elements
@@ -473,21 +475,21 @@ class Calendar(ttk.Frame):
     def __setitem__(self, key, value):
         if key not in self._properties:
             raise AttributeError("Calendar object has no attribute %s." % key)
-        elif key is "locale":
+        elif key == "locale":
             raise AttributeError("This attribute cannot be modified.")
         else:
-            if key is "selectmode":
-                if value is "none":
+            if key == "selectmode":
+                if value == "none":
                     for week in self._calendar:
                         for day in week:
                             day.unbind("<1>")
-                elif value is "day":
+                elif value == "day":
                     for week in self._calendar:
                         for day in week:
                             day.bind("<1>", self._on_click)
                 else:
                     raise ValueError("'selectmode' option should be 'none' or 'day'.")
-            elif key is 'textvariable':
+            elif key == 'textvariable':
                 try:
                     if self._textvariable is not None:
                         self._textvariable.trace_remove('write', self._textvariable_trace_id)
@@ -500,27 +502,27 @@ class Calendar(ttk.Frame):
                         value.trace('w', self._textvariable_trace)
                 self._textvariable = value
                 value.set(value.get())
-            elif key is 'showweeknumbers':
+            elif key == 'showweeknumbers':
                 if value:
                     for wlabel in self._week_nbs:
                         wlabel.grid()
                 else:
                     for wlabel in self._week_nbs:
                         wlabel.grid_remove()
-            elif key is 'firstweekday':
+            elif key == 'firstweekday':
                 if value not in ["monday", "sunday"]:
                     raise ValueError("'firstweekday' option should be 'monday' or 'sunday'.")
                 self._cal.firstweekday = (value == 'sunday') * 6
                 for label, day in zip(self._week_days, self._cal.iterweekdays()):
                     label.configure(text=self._day_names[day % 7])
                 self._display_calendar()
-            elif key is 'borderwidth':
+            elif key == 'borderwidth':
                 try:
                     bd = int(value)
                     self._cal_frame.pack_configure(padx=bd, pady=bd)
                 except ValueError:
                     raise ValueError('expected integer for the borderwidth option.')
-            elif key is 'state':
+            elif key == 'state':
                 if value not in ['normal', 'disabled']:
                     raise ValueError("bad state '%s': must be disabled or normal" % value)
                 else:
@@ -537,7 +539,7 @@ class Calendar(ttk.Frame):
                     self._r_month.state((state,))
                     for child in self._cal_frame.children.values():
                         child.state((state,))
-            elif key is "maxdate":
+            elif key == "maxdate":
                 if value is not None:
                     if isinstance(value, self.datetime):
                         value = value.date()
@@ -549,7 +551,7 @@ class Calendar(ttk.Frame):
                 self._r_year.state(['!disabled'])
                 self._l_month.state(['!disabled'])
                 self._l_year.state(['!disabled'])
-            elif key is "mindate":
+            elif key == "mindate":
                 if value is not None:
                     if isinstance(value, self.datetime):
                         value = value.date()
@@ -561,7 +563,7 @@ class Calendar(ttk.Frame):
                 self._r_year.state(['!disabled'])
                 self._l_month.state(['!disabled'])
                 self._l_year.state(['!disabled'])
-            elif key is "font":
+            elif key == "font":
                 font = Font(self, value)
                 prop = font.actual()
                 self._font.configure(**prop)
@@ -570,44 +572,44 @@ class Calendar(ttk.Frame):
                 size = max(prop["size"], 10)
                 self.style.configure('R.%s.TButton' % self._style_prefixe, arrowsize=size)
                 self.style.configure('L.%s.TButton' % self._style_prefixe, arrowsize=size)
-            elif key is "normalbackground":
+            elif key == "normalbackground":
                 self.style.configure('cal.%s.TFrame' % self._style_prefixe, background=value)
                 self.style.configure('normal.%s.TLabel' % self._style_prefixe, background=value)
                 self.style.configure('normal_om.%s.TLabel' % self._style_prefixe, background=value)
-            elif key is "normalforeground":
+            elif key == "normalforeground":
                 self.style.configure('normal.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "bordercolor":
+            elif key == "bordercolor":
                 self.style.configure('cal.%s.TFrame' % self._style_prefixe, background=value)
-            elif key is "othermonthforeground":
+            elif key == "othermonthforeground":
                 self.style.configure('normal_om.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "othermonthbackground":
+            elif key == "othermonthbackground":
                 self.style.configure('normal_om.%s.TLabel' % self._style_prefixe, background=value)
-            elif key is "othermonthweforeground":
+            elif key == "othermonthweforeground":
                 self.style.configure('we_om.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "othermonthwebackground":
+            elif key == "othermonthwebackground":
                 self.style.configure('we_om.%s.TLabel' % self._style_prefixe, background=value)
-            elif key is "selectbackground":
+            elif key == "selectbackground":
                 self.style.configure('sel.%s.TLabel' % self._style_prefixe, background=value)
-            elif key is "selectforeground":
+            elif key == "selectforeground":
                 self.style.configure('sel.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "disabledselectbackground":
+            elif key == "disabledselectbackground":
                 self.style.map('sel.%s.TLabel' % self._style_prefixe, background=[('disabled', value)])
-            elif key is "disabledselectforeground":
+            elif key == "disabledselectforeground":
                 self.style.map('sel.%s.TLabel' % self._style_prefixe, foreground=[('disabled', value)])
-            elif key is "disableddaybackground":
+            elif key == "disableddaybackground":
                 self.style.map('%s.TLabel' % self._style_prefixe, background=[('disabled', value)])
-            elif key is "disableddayforeground":
+            elif key == "disableddayforeground":
                 self.style.map('%s.TLabel' % self._style_prefixe, foreground=[('disabled', value)])
-            elif key is "weekendbackground":
+            elif key == "weekendbackground":
                 self.style.configure('we.%s.TLabel' % self._style_prefixe, background=value)
                 self.style.configure('we_om.%s.TLabel' % self._style_prefixe, background=value)
-            elif key is "weekendforeground":
+            elif key == "weekendforeground":
                 self.style.configure('we.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "headersbackground":
+            elif key == "headersbackground":
                 self.style.configure('headers.%s.TLabel' % self._style_prefixe, background=value)
-            elif key is "headersforeground":
+            elif key == "headersforeground":
                 self.style.configure('headers.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "background":
+            elif key == "background":
                 self.style.configure('main.%s.TFrame' % self._style_prefixe, background=value)
                 self.style.configure('main.%s.TLabel' % self._style_prefixe, background=value)
                 self.style.configure('R.%s.TButton' % self._style_prefixe, background=value,
@@ -616,11 +618,11 @@ class Calendar(ttk.Frame):
                 self.style.configure('L.%s.TButton' % self._style_prefixe, background=value,
                                      bordercolor=value,
                                      lightcolor=value, darkcolor=value)
-            elif key is "foreground":
+            elif key == "foreground":
                 self.style.configure('R.%s.TButton' % self._style_prefixe, arrowcolor=value)
                 self.style.configure('L.%s.TButton' % self._style_prefixe, arrowcolor=value)
                 self.style.configure('main.%s.TLabel' % self._style_prefixe, foreground=value)
-            elif key is "disabledbackground":
+            elif key == "disabledbackground":
                 self.style.map('%s.TButton' % self._style_prefixe,
                                background=[('active', '!disabled', self.style.lookup('TEntry', 'selectbackground', ('focus',))),
                                            ('disabled', value)],)
@@ -628,22 +630,22 @@ class Calendar(ttk.Frame):
                                background=[('disabled', value)])
                 self.style.map('main.%s.TLabel' % self._style_prefixe,
                                background=[('disabled', value)])
-            elif key is "disabledforeground":
+            elif key == "disabledforeground":
                 self.style.map('%s.TButton' % self._style_prefixe,
                                arrowcolor=[('disabled', value)])
                 self.style.map('main.%s.TLabel' % self._style_prefixe,
                                foreground=[('disabled', value)])
-            elif key is "cursor":
+            elif key == "cursor":
                 ttk.Frame.configure(self, cursor=value)
-            elif key is "tooltipbackground":
+            elif key == "tooltipbackground":
                 self.style.configure('%s.tooltip.TLabel' % self._style_prefixe,
                                      background=value)
-            elif key is "tooltipforeground":
+            elif key == "tooltipforeground":
                 self.style.configure('%s.tooltip.TLabel' % self._style_prefixe,
                                      foreground=value)
-            elif key is "tooltipalpha":
+            elif key == "tooltipalpha":
                 self.tooltip_wrapper.configure(alpha=value)
-            elif key is "tooltipdelay":
+            elif key == "tooltipdelay":
                 self.tooltip_wrapper.configure(delay=value)
             self._properties[key] = value
             if key in ['showothermonthdays', 'maxdate', 'mindate']:
@@ -652,7 +654,7 @@ class Calendar(ttk.Frame):
 
     def _textvariable_trace(self, *args):
         """Connect StringVar value with selected date."""
-        if self._properties.get("selectmode") is "day":
+        if self._properties.get("selectmode") == "day":
             date = self._textvariable.get()
             if not date:
                 self._remove_selection()
@@ -1043,7 +1045,7 @@ class Calendar(ttk.Frame):
     # --- bindings
     def _on_click(self, event):
         """Select the day on which the user clicked."""
-        if self._properties['state'] is 'normal':
+        if self._properties['state'] == 'normal':
             label = event.widget
             if "disabled" not in label.state():
                 day = label.cget("text")
@@ -1092,10 +1094,10 @@ class Calendar(ttk.Frame):
     def selection_get(self):
         """
         Return currently selected date (datetime.date instance).
-        Always return None if selectmode is "none".
+        Always return None if selectmode == "none".
         """
 
-        if self._properties.get("selectmode") is "day":
+        if self._properties.get("selectmode") == "day":
             return self._sel_date
         else:
             return None
@@ -1108,9 +1110,9 @@ class Calendar(ttk.Frame):
         instance or a string corresponding to the date format "%x"
         in the Calendar locale.
 
-        Do nothing if selectmode is "none".
+        Do nothing if selectmode == "none".
         """
-        if self._properties.get("selectmode") is "day" and self._properties['state'] is 'normal':
+        if self._properties.get("selectmode") == "day" and self._properties['state'] == 'normal':
             if date is None:
                 self._remove_selection()
                 self._sel_date = None

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -255,7 +255,7 @@ class Calendar(ttk.Frame):
 
         # --- date limits
         maxdate = kw.pop('maxdate', None)
-        mindate = kw.pop('maxdate', None)
+        mindate = kw.pop('mindate', None)
         if maxdate is not None:
             if isinstance(maxdate, self.datetime):
                 maxdate = maxdate.date()
@@ -264,7 +264,7 @@ class Calendar(ttk.Frame):
         if mindate is not None:
             if isinstance(mindate, self.datetime):
                 mindate = mindate.date()
-            elif not isinstance(maxdate, self.date):
+            elif not isinstance(mindate, self.date):
                 raise TypeError("expected %s for the 'mindate' option." % self.date)
 
         # --- selectmode

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -571,6 +571,19 @@ class Calendar(ttk.Frame):
                 self.style.configure('R.%s.TButton' % self._style_prefixe, arrowcolor=value)
                 self.style.configure('L.%s.TButton' % self._style_prefixe, arrowcolor=value)
                 self.style.configure('main.%s.TLabel' % self._style_prefixe, foreground=value)
+            elif key is "disabledbackground":
+                self.style.map('%s.TButton' % self._style_prefixe,
+                               background=[('active', '!disabled', self.style.lookup('TEntry', 'selectbackground', ('focus',))),
+                                           ('disabled', key)],)
+                self.style.map('main.%s.TFrame' % self._style_prefixe,
+                               background=[('disabled', key)])
+                self.style.map('main.%s.TLabel' % self._style_prefixe,
+                               background=[('disabled', key)])
+            elif key is "disabledforeground":
+                self.style.map('%s.TButton' % self._style_prefixe,
+                               arrowcolor=[('disabled', key)])
+                self.style.map('main.%s.TLabel' % self._style_prefixe,
+                               foreground=[('disabled', key)])
             elif key is "cursor":
                 ttk.Frame.configure(self, cursor=value)
             elif key is "tooltipbackground":
@@ -671,8 +684,7 @@ class Calendar(ttk.Frame):
                        darkcolor=[('active', active_bg)],
                        lightcolor=[('active', active_bg)])
         self.style.map('main.%s.TFrame' % self._style_prefixe,
-                       background=[('disabled', dis_bg)],
-                       foreground=[('disabled', dis_fg)])
+                       background=[('disabled', dis_bg)])
         self.style.map('main.%s.TLabel' % self._style_prefixe,
                        background=[('disabled', dis_bg)],
                        foreground=[('disabled', dis_fg)])

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -1129,9 +1129,17 @@ class Calendar(ttk.Frame):
         self._check_date_range()
 
     # --- selection handling
+    def selection_clear(self):
+        """Clear the selection."""
+        self._remove_selection()
+        self._sel_date = None
+        if self._textvariable is not None:
+            self._textvariable.set('')
+
     def selection_get(self):
         """
         Return currently selected date (datetime.date instance).
+
         Always return None if selectmode == "none".
         """
 
@@ -1144,18 +1152,15 @@ class Calendar(ttk.Frame):
         """
         Set the selection to date.
 
-        date can be either a datetime.date
-        instance or a string corresponding to the date format "%x"
-        in the Calendar locale.
+            date : datetime.date, datetime.datetime or str
+                    date to be made visible. If given as a string, it should be
+                    in the format corresponding to the calendar locale.
 
         Do nothing if selectmode == "none".
         """
         if self._properties.get("selectmode") == "day" and self._properties['state'] == 'normal':
             if date is None:
-                self._remove_selection()
-                self._sel_date = None
-                if self._textvariable is not None:
-                    self._textvariable.set('')
+                self.selection_clear()
             else:
                 if isinstance(date, self.datetime):
                     self._sel_date = date.date()

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -546,16 +546,22 @@ class Calendar(ttk.Frame):
                         raise TypeError("expected %s for the 'maxdate' option." % self.date)
                     if self._date > value:
                         self._date = self._date.replace(year=value.year, month=value.month)
-                        self.event_generate('<<CalendarMonthChanged>>')
+                self._r_month.state(['!disabled'])
+                self._r_year.state(['!disabled'])
+                self._l_month.state(['!disabled'])
+                self._l_year.state(['!disabled'])
             elif key is "mindate":
                 if value is not None:
                     if isinstance(value, self.datetime):
                         value = value.date()
                     elif not isinstance(value, self.date):
                         raise TypeError("expected %s for the 'mindate' option." % self.date)
-                    if self._date < value.replace(day=1):
+                    if self._date < value:
                         self._date = self._date.replace(year=value.year, month=value.month)
-                        self.event_generate('<<CalendarMonthChanged>>')
+                self._r_month.state(['!disabled'])
+                self._r_year.state(['!disabled'])
+                self._l_month.state(['!disabled'])
+                self._l_year.state(['!disabled'])
             elif key is "font":
                 font = Font(self, value)
                 prop = font.actual()
@@ -1112,6 +1118,8 @@ class Calendar(ttk.Frame):
                 self._date = self._sel_date.replace(day=1)
                 self._display_calendar()
                 self._display_selection()
+                self._check_next()
+                self._check_prev()
 
     def get_displayed_month(self):
         """Return the currently displayed month in the form of a (month, year) tuple."""

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -68,11 +68,11 @@ class Calendar(ttk.Frame):
         firstweekday : "monday" or "sunday"
             first day of the week
 
-        mindate : datetime.date (default None)
+        mindate : datetime.date or datetime.datetime (default is None)
             minimum allowed date
 
-        maxdate : datetime.date (default None)
-            maxdate allowed date
+        maxdate : datetime.date or datetime.datetime (default is None)
+            maximum allowed date
 
         showweeknumbers : bool (default is True)
             whether to display week numbers.
@@ -1139,7 +1139,7 @@ class Calendar(ttk.Frame):
 
         Options:
 
-            date : datetime.date or datetime.datetime instance.
+            date : datetime.date or datetime.datetime
                 event date
 
             text : str

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -1141,9 +1141,10 @@ class Calendar(ttk.Frame):
                         self._sel_date = self.parse_date(date)
                     except Exception:
                         raise ValueError("%r is not a valid date." % date)
-                if self._sel_date < self['mindate']:
+                print(date, self._sel_date)
+                if self['mindate'] is not None and self._sel_date < self['mindate']:
                     self._sel_date = self['mindate']
-                elif self._sel_date > self['maxdate']:
+                elif self['maxdate'] is not None and self._sel_date > self['maxdate']:
                     self._sel_date = self['maxdate']
                 if self._textvariable is not None:
                     self._textvariable.set(self.format_date(self._sel_date))

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     import Tkinter as tk
     import ttk
+
 from tkcalendar.calendar_ import Calendar
 
 

--- a/tkcalendar/tooltip.py
+++ b/tkcalendar/tooltip.py
@@ -19,14 +19,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Tooltip and TooltipWrapper
 """
-
+from sys import platform
 try:
     import tkinter as tk
     from tkinter import ttk
 except ImportError:
     import Tkinter as tk
     import ttk
-from sys import platform
 
 
 class Tooltip(tk.Toplevel):


### PR DESCRIPTION
- New options:
  - *disabledforeground* and *disabledbackground*: colors of calendar border and  month/year name in disabled state  
  - *maxdate* and *mindate*: set an allowed date range for date selection
- New `Calendar.see()` method: make sure given date is visible
- Make `Calendar.selection_clear()` actually clear the selection
