### PR TITLE
Add weekenddays option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,6 +86,9 @@ Widget keyword options
 
     firstweekday : "monday" or "sunday"
         first day of the week
+        
+    weekenddays : list
+        days to be displayed as week-end days given as a list of integers corresponding to the number of the day in the week (e.g. [6, 7] for the last two days of the week).
 
     mindate : datetime.date or datetime.datetime (default is None)
         minimum allowed date
@@ -356,6 +359,7 @@ Changelog
     * Add *disabledforeground* and *disabledbackground* options to further customize
       the disabled state appearance of the Calendar
     * Add *maxdate* and *mindate* options to set an allowed date range for date selection
+    * Add *weekenddays* option to choose the days colored as week-end days (Fix `#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
     * Add ``Calendar.see()`` method to make sure a date is visible
     * Make ``Calendar.selection_clear()`` actually clear the selection
 

--- a/README.rst
+++ b/README.rst
@@ -221,7 +221,7 @@ Widget methods
 
             Options:
 
-                *date*: datetime.date or datetime.datetime instance.
+                *date*: ``datetime.date`` or ``datetime.datetime`` instance.
 
                 *text*: text to put in the tooltip associated to date.
 
@@ -267,15 +267,23 @@ Widget methods
 
         get_displayed_month() :
             Return the currently displayed month in the form of a (month, year) tuple.
+            
+        see(date) : 
+            Display the month in which *date* is. 
+            
+                *date*: ``datetime.date`` or ``datetime.datetime`` instance.
 
+        selection_clear() :
+            Clear the selection. 
+            
         selection_get() :
             If selectmode is 'day', return the selected date as a ``datetime.date``
             instance, otherwise return ``None``.
 
         selection_set(self, date) :
-            If selectmode is 'day', set the selection to *date* where *date* can be either a ``datetime.date``
-             instance or a string corresponding to the date format ``"%x"`` in the ``Calendar``
-             locale. Does nothing if selectmode is ``"none"``.
+            If selectmode is 'day', set the selection to *date* where *date* can be either a ``datetime.date`` 
+            instance or a string corresponding to the date format ``"%x"`` in the ``Calendar`` 
+            locale. Does nothing if selectmode is ``"none"``.
 
         tag_cget(tag, option) :
             Return the value of the tag's option.

--- a/docs/Calendar.rst
+++ b/docs/Calendar.rst
@@ -43,6 +43,10 @@ Class
 
        firstweekday : str
           first day of the week: "monday" or "sunday"
+          
+       weekenddays : list
+          days to be displayed as week-end days given as a list of integers corresponding to the number of the day in the week (e.g. [6, 7] for the last two days of the week).
+
 
        mindate : datetime.date or datetime.datetime (default is None)
             minimum allowed date

--- a/docs/Calendar.rst
+++ b/docs/Calendar.rst
@@ -10,7 +10,7 @@ Class
 
 .. autoclass:: tkcalendar.Calendar
     :show-inheritance:
-    :members: calevent_cget, calevent_configure, calevent_create, calevent_lower, calevent_raise, calevent_remove, format_date, get_calevents, get_date, keys, selection_get, selection_set, tag_cget, tag_config, tag_delete, tag_names, get_displayed_month, see
+    :members: calevent_cget, calevent_configure, calevent_create, calevent_lower, calevent_raise, calevent_remove, format_date, get_calevents, get_date, keys, selection_clear, selection_get, selection_set, tag_cget, tag_config, tag_delete, tag_names, get_displayed_month, see
 
     .. py:method:: __init__(master=None, **kw)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ tkcalendar 1.5.0
   
 - *maxdate* and *mindate*: set an allowed date range for date selection
 
+- *weekenddays*: choose the days colored as week-end days (Fix `#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
+
 .. rubric:: New features
 
 - :meth:`Calendar.see` method: make sure given date is visible

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,7 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
-
+from tkcalendar import __version__
 
 # -- Project information -----------------------------------------------------
 
@@ -24,9 +24,9 @@ copyright = '2018, Juliette Monsel'
 author = 'Juliette Monsel'
 
 # The short X.Y version
-version = ''
+version = __version__
 # The full version, including alpha/beta/rc tags
-release = '1.3.1'
+release = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='tkcalendar',
-      version='1.4.0',
+      version='1.5.0',
       description='Calendar and DateEntry widgets for Tkinter',
       long_description=long_description,
       url='https://github.com/j4321/tkcalendar',

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -424,7 +424,7 @@ class TestCalendar(BaseWidgetTest):
         widget.config(tooltipbackground='cyan')
         self.assertEqual(widget["tooltipbackground"], 'cyan')
 
-    def test_calevents(self):
+    def test_calendar_calevents(self):
         widget = Calendar(self.window)
         widget.pack()
         self.window.update()
@@ -562,3 +562,12 @@ class TestCalendar(BaseWidgetTest):
         widget._r_year.invoke()
         self.window.update()
         self.assertTrue(self.event_triggered)
+
+    def test_calendar_other_fcts(self):
+        widget = Calendar(self.window, mindate=date(2018, 1, 6), maxdate=date(2018, 9, 8))
+        widget.pack()
+        self.window.update()
+
+        self.assertEqual(widget.check_date_range(date(2018, 4, 11)), date(2018, 4, 11))
+        self.assertEqual(widget.check_date_range(date(2017, 4, 11)), date(2018, 1, 6))
+        self.assertEqual(widget.check_date_range(date(2018, 12, 1)), date(2018, 9, 8))

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -71,6 +71,36 @@ class TestCalendar(BaseWidgetTest):
             widget.destroy()
 
         with self.assertRaises(TypeError):
+            widget = Calendar(self.window, weekenddays=7)
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(ValueError):
+            widget = Calendar(self.window, weekenddays="e")
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(ValueError):
+            widget = Calendar(self.window, weekenddays=[1])
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(ValueError):
+            widget = Calendar(self.window, weekenddays=['a', 'b'])
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(ValueError):
+            widget = Calendar(self.window, weekenddays=[12, 3])
+            widget.pack()
+            self.window.update()
+            widget.destroy()
+
+        with self.assertRaises(TypeError):
             widget = Calendar(self.window, maxdate="e")
             widget.pack()
             self.window.update()
@@ -245,6 +275,7 @@ class TestCalendar(BaseWidgetTest):
                    'mindate',
                    'maxdate',
                    'firstweekday',
+                   'weekenddays',
                    'showweeknumbers',
                    'showothermonthdays',
                    'selectbackground',
@@ -312,6 +343,13 @@ class TestCalendar(BaseWidgetTest):
         self.assertEqual(widget["firstweekday"], 'sunday')
         with self.assertRaises(ValueError):
             widget.config(firstweekday="a")
+
+        widget.config(weekenddays=[5, 7])
+        self.window.update()
+        we_style = 'we.%s.TLabel' % widget._style_prefixe
+        normal_style = 'normal.%s.TLabel' % widget._style_prefixe
+        for i in range(7):
+            self.assertEqual(widget._calendar[0][i].cget('style'), we_style if (i + 1) in [5, 7] else normal_style)
 
         widget["mindate"] = datetime(2018, 9, 10)
         self.assertEqual(widget["mindate"], date(2018, 9, 10))

--- a/tests/test_dateentry.py
+++ b/tests/test_dateentry.py
@@ -86,7 +86,8 @@ class TestDateEntry(BaseWidgetTest):
 
     def test_dateentry_functions(self):
         widget = DateEntry(self.window, width=12, background='darkblue',
-                           foreground='white', borderwidth=2)
+                           foreground='white', borderwidth=2,
+                           mindate=date(2014, 1, 6), maxdate=date(2019, 9, 8))
         widget.pack()
         self.window.update()
 
@@ -97,6 +98,19 @@ class TestDateEntry(BaseWidgetTest):
         widget.set_date(date(2015, 12, 31))
         self.assertEqual(widget.get_date(), date(2015, 12, 31))
         self.assertEqual(widget.get(), format_date(date(2015, 12, 31), 'short'))
+
+        widget.delete(0, "end")
+        widget.insert(0, format_date(date(2010, 12, 31), 'short'))
+        self.window.focus_force()
+        self.assertEqual(widget.get_date(), date(2014, 1, 6))
+        widget.delete(0, "end")
+        widget.insert(0, format_date(date(2020, 12, 31), 'short'))
+        self.window.focus_force()
+        self.assertEqual(widget.get_date(), date(2019, 9, 8))
+        widget.delete(0, "end")
+        widget.insert(0, format_date(date(2015, 12, 31), 'short'))
+        self.window.focus_force()
+        self.assertEqual(widget.get_date(), date(2015, 12, 31))
 
         widget.delete(0, "end")
         widget.insert(0, "abc")

--- a/tests/test_dateentry.py
+++ b/tests/test_dateentry.py
@@ -98,6 +98,12 @@ class TestDateEntry(BaseWidgetTest):
         widget.set_date(date(2015, 12, 31))
         self.assertEqual(widget.get_date(), date(2015, 12, 31))
         self.assertEqual(widget.get(), format_date(date(2015, 12, 31), 'short'))
+        widget.set_date(date(2010, 12, 31))
+        self.assertEqual(widget.get_date(), date(2014, 1, 6))
+        widget.set_date(date(2020, 12, 31))
+        self.assertEqual(widget.get_date(), date(2019, 9, 8))
+        widget.set_date(date(2015, 12, 31))
+        self.assertEqual(widget.get_date(), date(2015, 12, 31))
 
         widget.delete(0, "end")
         widget.insert(0, format_date(date(2010, 12, 31), 'short'))

--- a/tkcalendar/__init__.py
+++ b/tkcalendar/__init__.py
@@ -25,3 +25,5 @@ tkcalendar module providing Calendar and DateEntry widgets
 
 from tkcalendar.dateentry import DateEntry
 from tkcalendar.calendar_ import Calendar
+
+__version__ = '1.5.0'

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -227,7 +227,7 @@ class Calendar(ttk.Frame):
         weekenddays = kw.pop("weekenddays", None)
         if not weekenddays:
             l = list(self._cal.iterweekdays())
-            weekenddays = [l.index(5), l.index(6)]  # saturday and sunday
+            weekenddays = [l.index(5) + 1, l.index(6) + 1]  # saturday and sunday
         self._check_weekenddays(weekenddays)
 
         # --- locale

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -471,7 +471,7 @@ class Calendar(ttk.Frame):
 
         self._setup_style()
         self._display_calendar()
-        self._check_date_range()
+        self._btns_date_range()
         self._check_sel_date()
 
         if self._textvariable is not None:
@@ -677,7 +677,7 @@ class Calendar(ttk.Frame):
                        'maxdate', 'mindate']:
                 self._display_calendar()
                 self._check_sel_date()
-                self._check_date_range()
+                self._btns_date_range()
 
     @staticmethod
     def _check_weekenddays(weekenddays):
@@ -1007,6 +1007,24 @@ class Calendar(ttk.Frame):
             self.tooltip_wrapper.remove_tooltip(label)
             self.tooltip_wrapper.add_tooltip(label, text)
 
+    def check_date_range(self, date):
+        """
+        Ensure that date is in the allowed date range.
+
+            date : datetime.date or datetime.datetime
+
+        Return date if date is in the allowed date range, return the closest
+        bound otherwise.
+        """
+        maxdate = self['maxdate']
+        mindate = self['mindate']
+        if maxdate is not None and date > maxdate:
+            return maxdate
+        elif mindate is not None and date < mindate:
+            return mindate
+        else:
+            return date
+
     def _check_sel_date(self):
 
         if self._sel_date is not None:
@@ -1019,8 +1037,8 @@ class Calendar(ttk.Frame):
                 self._sel_date = mindate
                 self._display_selection()
 
-    def _check_date_range(self):
-        """Disable/enable buttons depending on allowed date range"""
+    def _btns_date_range(self):
+        """Disable/enable buttons depending on allowed date range."""
         maxdate = self['maxdate']
         mindate = self['mindate']
 
@@ -1078,7 +1096,7 @@ class Calendar(ttk.Frame):
             self.timedelta(days=calendar.monthrange(year, month)[1])
         self._display_calendar()
         self.event_generate('<<CalendarMonthChanged>>')
-        self._check_date_range()
+        self._btns_date_range()
 
     def _prev_month(self):
         """Display the previous month."""
@@ -1086,7 +1104,7 @@ class Calendar(ttk.Frame):
         self._date = self._date.replace(day=1)
         self._display_calendar()
         self.event_generate('<<CalendarMonthChanged>>')
-        self._check_date_range()
+        self._btns_date_range()
 
     def _next_year(self):
         """Display the next year."""
@@ -1094,7 +1112,7 @@ class Calendar(ttk.Frame):
         self._date = self._date.replace(year=year + 1)
         self._display_calendar()
         self.event_generate('<<CalendarMonthChanged>>')
-        self._check_date_range()
+        self._btns_date_range()
 
     def _prev_year(self):
         """Display the previous year."""
@@ -1102,7 +1120,7 @@ class Calendar(ttk.Frame):
         self._date = self._date.replace(year=year - 1)
         self._display_calendar()
         self.event_generate('<<CalendarMonthChanged>>')
-        self._check_date_range()
+        self._btns_date_range()
 
     # --- bindings
     def _on_click(self, event):
@@ -1150,7 +1168,7 @@ class Calendar(ttk.Frame):
 
         self._date = self._date.replace(month=date.month, year=date.year)
         self._display_calendar()
-        self._check_date_range()
+        self._btns_date_range()
 
     # --- selection handling
     def selection_clear(self):
@@ -1205,7 +1223,7 @@ class Calendar(ttk.Frame):
                 self._date = self._sel_date.replace(day=1)
                 self._display_calendar()
                 self._display_selection()
-                self._check_date_range()
+                self._btns_date_range()
 
     def get_displayed_month(self):
         """Return the currently displayed month in the form of a (month, year) tuple."""

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -1195,7 +1195,6 @@ class Calendar(ttk.Frame):
                         self._sel_date = self.parse_date(date)
                     except Exception:
                         raise ValueError("%r is not a valid date." % date)
-                print(date, self._sel_date)
                 if self['mindate'] is not None and self._sel_date < self['mindate']:
                     self._sel_date = self['mindate']
                 elif self['maxdate'] is not None and self._sel_date > self['maxdate']:

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -67,13 +67,17 @@ class Calendar(ttk.Frame):
         day : int
             initially selected day, if month or year is given but not day, no initial selection, otherwise, default is today.
 
-        firstweekday : "monday" or "sunday"
+        firstweekday : "monday" (default) or "sunday"
             first day of the week
 
-        mindate : datetime.date or datetime.datetime (default is None)
+        weekenddays : list
+            days to be displayed as week-end days given as a list of integers corresponding to the number of the day in the week
+            (e.g. [6, 7] for the last two days of the week).
+
+        mindate : None (default), datetime.date or datetime.datetime
             minimum allowed date
 
-        maxdate : datetime.date or datetime.datetime (default is None)
+        maxdate : None (default), datetime.date or datetime.datetime
             maximum allowed date
 
         showweeknumbers : bool (default is True)
@@ -220,6 +224,12 @@ class Calendar(ttk.Frame):
             raise ValueError("'firstweekday' option should be 'monday' or 'sunday'.")
         self._cal = calendar.TextCalendar((firstweekday == 'sunday') * 6)
 
+        weekenddays = kw.pop("weekenddays", None)
+        if not weekenddays:
+            l = list(self._cal.iterweekdays())
+            weekenddays = [l.index(5), l.index(6)]  # saturday and sunday
+        self._check_weekenddays(weekenddays)
+
         # --- locale
         locale = kw.pop("locale", getdefaultlocale()[0])
         self._day_names = get_day_names('abbreviated', locale=locale)
@@ -298,6 +308,7 @@ class Calendar(ttk.Frame):
                    'showweeknumbers',
                    'showothermonthdays',
                    'firstweekday',
+                   'weekenddays',
                    'selectbackground',
                    'selectforeground',
                    'disabledselectbackground',
@@ -337,6 +348,7 @@ class Calendar(ttk.Frame):
                             "selectmode": selectmode,
                             'textvariable': self._textvariable,
                             'firstweekday': firstweekday,
+                            'weekenddays': weekenddays,
                             'mindate': mindate,
                             'maxdate': maxdate,
                             'showweeknumbers': showweeknumbers,
@@ -518,7 +530,8 @@ class Calendar(ttk.Frame):
                 self._cal.firstweekday = (value == 'sunday') * 6
                 for label, day in zip(self._week_days, self._cal.iterweekdays()):
                     label.configure(text=self._day_names[day % 7])
-                self._display_calendar()
+            elif key == 'weekenddays':
+                self._check_weekenddays(value)
             elif key == 'borderwidth':
                 try:
                     bd = int(value)
@@ -660,10 +673,23 @@ class Calendar(ttk.Frame):
             elif key == "tooltipdelay":
                 self.tooltip_wrapper.configure(delay=value)
             self._properties[key] = value
-            if key in ['showothermonthdays', 'maxdate', 'mindate']:
+            if key in ['showothermonthdays', 'firstweekday', 'weekenddays',
+                       'maxdate', 'mindate']:
                 self._display_calendar()
                 self._check_sel_date()
                 self._check_date_range()
+
+    @staticmethod
+    def _check_weekenddays(weekenddays):
+        try:
+            if len(weekenddays) != 2:
+                raise ValueError("weekenddays should be a list of two days.")
+            else:
+                for d in weekenddays:
+                    if d not in range(1, 8):
+                        raise ValueError("weekenddays should contain integers between 1 and 7.")
+        except TypeError:
+            raise TypeError("weekenddays should be a list of two days.")
 
     def _textvariable_trace(self, *args):
         """Connect StringVar value with selected date."""
@@ -809,9 +835,8 @@ class Calendar(ttk.Frame):
             cal.append([(0, i) for i in range(7)])
 
         week_days = {i: 'normal.%s.TLabel' % self._style_prefixe for i in range(7)}  # style names depending on the type of day
-        offset = (self['firstweekday'] == 'sunday') * 6
-        week_days[(5 - offset) % 7] = 'we.%s.TLabel' % self._style_prefixe
-        week_days[(6 - offset) % 7] = 'we.%s.TLabel' % self._style_prefixe
+        week_days[self['weekenddays'][0] - 1] = 'we.%s.TLabel' % self._style_prefixe
+        week_days[self['weekenddays'][1] - 1] = 'we.%s.TLabel' % self._style_prefixe
         _, week_nb, d = self._date.isocalendar()
         if d == 7 and self['firstweekday'] == 'sunday':
             week_nb += 1
@@ -863,9 +888,8 @@ class Calendar(ttk.Frame):
                 cal.append(self._cal.monthdatescalendar(y, next_m)[i + 1])
 
         week_days = {i: 'normal' for i in range(7)}  # style names depending on the type of day
-        offset = (self['firstweekday'] == 'sunday') * 6
-        week_days[(5 - offset) % 7] = 'we'
-        week_days[(6 - offset) % 7] = 'we'
+        week_days[self['weekenddays'][0] - 1] = 'we'
+        week_days[self['weekenddays'][1] - 1] = 'we'
         prev_m = (month - 2) % 12 + 1
         months = {month: '.%s.TLabel' % self._style_prefixe,
                   next_m: '_om.%s.TLabel' % self._style_prefixe,

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -339,15 +339,7 @@ class DateEntry(ttk.Entry):
         ttk.Entry.configure(self, **entry_kw)
         self._calendar.configure(**kw)
 
-    def config(self, **kw):
-        """
-        Configure resources of a widget.
-
-        The values for resources are specified as keyword
-        arguments. To get an overview about
-        the allowed keyword arguments call the method keys.
-        """
-        self.configure(**kw)
+    config = configure
 
     def set_date(self, date):
         """
@@ -365,6 +357,7 @@ class DateEntry(ttk.Entry):
             except Exception:
                 raise ValueError("%r is not a valid date." % date)
         self._set_text(txt)
+        self._validate_date()
 
     def get_date(self):
         """Return the content of the DateEntry as a datetime.date instance."""

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -103,7 +103,7 @@ class DateEntry(ttk.Entry):
         self._setup_style()
         self.configure(style=style)
 
-        # add validation to Entry so that only date in the locale '%x' format
+        # add validation to Entry so that only dates in the locale's format
         # are accepted
         validatecmd = self.register(self._validate_date)
         self.configure(validate='focusout',
@@ -234,8 +234,13 @@ class DateEntry(ttk.Entry):
     def _validate_date(self):
         """Date entry validation: only dates in locale '%x' format are accepted."""
         try:
-            self._date = self.parse_date(self.get())
-            return True
+            date = self.parse_date(self.get())
+            self._date = self._calendar.check_date_range(date)
+            if self._date != date:
+                self._set_text(self.format_date(self._date))
+                return False
+            else:
+                return True
         except (ValueError, IndexError):
             self._set_text(self.format_date(self._date))
             return False


### PR DESCRIPTION
Add option *weekenddays* to choose the days colored as week-end days because it can be different depending on the country. Saturday and Sunday are chosen by default.
Fix #37 