### PR TITLE
Fix locale

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -375,6 +375,7 @@ Changelog
     * Add *weekenddays* option to choose the days colored as week-end days (Fix `#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
     * Add ``Calendar.see()`` method to make sure a date is visible
     * Make ``Calendar.selection_clear()`` actually clear the selection
+    * Fix ``ValueError`` when retrieving default locale
 
 - tkcalendar 1.4.0
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ tkcalendar 1.5.0
 .. rubric:: Bug fixes
 
 - Make :meth:`Calendar.selection_clear` actually clear the selection
+- Fix :obj:`ValueError` when retrieving default locale
 
 
 tkcalendar 1.4.0

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -232,6 +232,8 @@ class Calendar(ttk.Frame):
 
         # --- locale
         locale = kw.pop("locale", default_locale())
+        if locale is None:
+            locale = 'en'
         self._day_names = get_day_names('abbreviated', locale=locale)
         self._month_names = get_month_names('wide', locale=locale)
 

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -17,7 +17,7 @@ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 
 Calendar widget
@@ -25,7 +25,6 @@ Calendar widget
 
 
 import calendar
-from locale import getdefaultlocale
 try:
     from tkinter import ttk
     from tkinter.font import Font
@@ -33,6 +32,7 @@ except ImportError:
     import ttk
     from tkFont import Font
 
+from babel import default_locale
 from babel.dates import format_date, parse_date, get_day_names, get_month_names
 
 from tkcalendar.tooltip import TooltipWrapper
@@ -231,7 +231,7 @@ class Calendar(ttk.Frame):
         self._check_weekenddays(weekenddays)
 
         # --- locale
-        locale = kw.pop("locale", getdefaultlocale()[0])
+        locale = kw.pop("locale", default_locale())
         self._day_names = get_day_names('abbreviated', locale=locale)
         self._month_names = get_month_names('wide', locale=locale)
 


### PR DESCRIPTION
Fix ``ValueError`` when retrieving a default locale not defined in the usual way (happens sometimes in Windows):
- Replace ``locale.getdefaultlocale()`` by ``babel.default_locale()``
- Set fallback locale to "en"