### PR TITLE
Fix date parsing for Swedish locale (and others)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -26,6 +26,6 @@ import babel.dates
 locale.setlocale(locale.LC_ALL, '')
 
 
-def format_date(date, length):
-    return babel.dates.format_date(date, length, locale=locale.getdefaultlocale()[0])
+def format_date(date, length, locale=locale.getdefaultlocale()[0]):
+    return babel.dates.format_date(date, length, locale)
 

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -176,6 +176,11 @@ class TestCalendar(BaseWidgetTest):
         self.assertEqual(widget.selection_get(), date(2010, 1, 1))
         widget.selection_clear()
         self.assertIsNone(widget.selection_get())
+        # test Swedish locale
+        widget.destroy()
+        widget = Calendar(self.window, locale='sv_SE')
+        widget.pack()
+        widget.selection_set(format_date(date(2012, 4, 11), 'short', 'sv_SE'))
 
     def test_calendar_buttons_functions(self):
         widget = Calendar(self.window)


### PR DESCRIPTION
Use code from `babel.dates.parse_date()` but explicitly pass
`format='short'` to `babel.dates.get_date_format()` to avoid errors when
'medium' and 'short' format do not have the year at the same place like
in Swedish. I have open a pull request in `babel` to fix this issue
upstream.

Closes https://github.com/j4321/tkcalendar/issues/44