### PR TITLE
Improve ttk theme compliance of the DateEntry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,7 @@ Widget keyword options
 
     firstweekday : "monday" or "sunday"
         first day of the week
-        
+
     weekenddays : list
         days to be displayed as week-end days given as a list of integers corresponding to the number of the day in the week (e.g. [6, 7] for the last two days of the week).
 
@@ -272,22 +272,22 @@ Widget methods
 
         get_displayed_month() :
             Return the currently displayed month in the form of a (month, year) tuple.
-            
-        see(date) : 
-            Display the month in which *date* is. 
-            
+
+        see(date) :
+            Display the month in which *date* is.
+
                 *date*: ``datetime.date`` or ``datetime.datetime`` instance.
 
         selection_clear() :
-            Clear the selection. 
-            
+            Clear the selection.
+
         selection_get() :
             If selectmode is 'day', return the selected date as a ``datetime.date``
             instance, otherwise return ``None``.
 
         selection_set(self, date) :
-            If selectmode is 'day', set the selection to *date* where *date* can be either a ``datetime.date`` 
-            instance or a string corresponding to the date format ``"%x"`` in the ``Calendar`` 
+            If selectmode is 'day', set the selection to *date* where *date* can be either a ``datetime.date``
+            instance or a string corresponding to the date format ``"%x"`` in the ``Calendar``
             locale. Does nothing if selectmode is ``"none"``.
 
         tag_cget(tag, option) :
@@ -372,11 +372,12 @@ Changelog
     * Add *disabledforeground* and *disabledbackground* options to further customize
       the disabled state appearance of the Calendar
     * Add *maxdate* and *mindate* options to set an allowed date range for date selection
-    * Add *weekenddays* option to choose the days colored as week-end days (Fix `#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
+    * Add *weekenddays* option to choose the days colored as week-end days (`#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
     * Add ``Calendar.see()`` method to make sure a date is visible
     * Make ``Calendar.selection_clear()`` actually clear the selection
     * Fix ``ValueError`` when retrieving default locale
-    * Fix date parsing error in Swedish locale and some others. (Fix `#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
+    * Fix date parsing error in Swedish locale and some others (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
+    * Improve compliance with ttk themes by making the DateEntry look like a Combobox (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
 
 - tkcalendar 1.4.0
 

--- a/README.rst
+++ b/README.rst
@@ -370,95 +370,81 @@ Changelog
 - tkcalendar 1.5.0
 
     * Add *disabledforeground* and *disabledbackground* options to further customize
-      the disabled state appearance of the Calendar
+      the disabled state appearance of the ``Calendar``
     * Add *maxdate* and *mindate* options to set an allowed date range for date selection
     * Add *weekenddays* option to choose the days colored as week-end days (`#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
     * Add ``Calendar.see()`` method to make sure a date is visible
     * Make ``Calendar.selection_clear()`` actually clear the selection
     * Fix ``ValueError`` when retrieving default locale
     * Fix date parsing error in Swedish locale and some others (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
-    * Improve compliance with ttk themes by making the DateEntry look like a Combobox (`#42 <https://github.com/j4321/tkcalendar/issues/42>`_)
+    * Improve compliance with ttk themes by making the ``DateEntry`` look like a ``ttk.Combobox`` (`#42 <https://github.com/j4321/tkcalendar/issues/42>`_)
 
 - tkcalendar 1.4.0
 
-    * Add ``<<CalendarMonthChanged>>`` virtual event to the Calendar widget
-    * Add ``get_displayed_month()`` method to the Calendar widget
+    * Add ``<<CalendarMonthChanged>>`` virtual event to the ``Calendar`` widget
+    * Add ``get_displayed_month()`` method to the ``Calendar`` widget
     * Add *showothermonthdays* option to show/hide the last and first days of the previous and next months
     * Fix display of events for January days showing on December page and conversely
 
 - tkcalendar 1.3.1
 
-    * Fix bug in day selection when firstweekday is sunday
+    * Fix bug in day selection when firstweekday is 'sunday'
 
 - tkcalendar 1.3.0
 
-    * No longer set locale globally to avoid conflicts between several instances, use babel module instead
-    * Add option *showwekknumbers* to show/hide week numbers
-    * Add option *firstweekday* to choose first week day between 'monday' and 'sunday'
-    * Make DateEntry compatible with more ttk themes, especially OSX default theme
+    * No longer set locale globally to avoid conflicts between several instances, use ``babel`` module instead
+    * Add *showwekknumbers* option to show/hide week numbers
+    * Add *firstweekday* option to choose first week day between 'monday' and 'sunday'
+    * Make ``DateEntry`` compatible with more ttk themes, especially OSX default theme
     * Add possibility to display special events (like birthdays, ..) in the calendar.
       The events are displayed with colors defined by tags and the event description is displayed in a tooltip
       (see documentation).
 
 - tkcalendar 1.2.1
 
-    * Fix ``ValueError`` in DateEntry with Python 3.6.5
+    * Fix ``ValueError`` in ``DateEntry`` with Python 3.6.5
 
 - tkcalendar 1.2.0
 
-    * Add textvariable option to Calendar
-    * Add state ('normal' or 'disabled') option to Calendar
-    * Add options *disabledselectbackground*, *disabledselectforeground*,
-      *disableddaybackground* and *disableddayforeground* to configure colors
-      when Calendar is disabled
-    * Fix DateEntry behavior in readonly mode
-    * Make Calendar.selection_get() always return a ``datetime.date``
+    * Add *textvariable* option to ``Calendar``
+    * Add *state* ('normal' or 'disabled') option to Calendar
+    * Add *disabledselectbackground*, *disabledselectforeground*,
+      *disableddaybackground* and *disableddayforeground* options to configure colors
+      when ``Calendar`` is disabled
+    * Fix ``DateEntry`` behavior in readonly mode
+    * Make ``Calendar.selection_get()`` always return a ``datetime.date``
 
 - tkcalendar 1.1.5
 
-    * Fix endless triggering of ``<<ThemeChanged>>`` event in DateEntry
+    * Fix endless triggering of ``<<ThemeChanged>>`` event in ``DateEntry``
 
 - tkcalendar 1.1.4
 
-    * Fix error in january due to week 53
-    * Fix DateEntry for ttk themes other than 'clam'
+    * Fix error in January due to week 53
+    * Fix ``DateEntry`` for ttk themes other than 'clam'
 
 - tkcalendar 1.1.3
 
-    * Make DateEntry support initialisation with partial dates (e.g. just year=2010)
+    * Make ``DateEntry`` support initialisation with partial dates (e.g. just year=2010)
     * Improve handling of wrong year-month-day combinations
 
 - tkcalendar 1.1.2
 
-    * Fix bug after destroying a DateEntry
+    * Fix bug after destroying a ``DateEntry``
     * Fix bug in style and font
 
 - tkcalendar 1.1.1
 
-    * Fix bug when content of DateEntry is not a valid date
+    * Fix bug when content of ``DateEntry`` is not a valid date
 
 - tkcalendar 1.1.0
 
-    * Bug fix:
-
-        + Fix display of the first days of the next month
-
-        + Increment year when going from december to january
-
-    * New widget:
-
-        + DateEntry, date selection entry with drop-down calendar
-
-    * New options in Calendar:
-
-        + borderwidth: width of the border around the calendar (integer)
-
-        + othermonthbackground: background color for normal week days belonging to the previous/next month
-
-        + othermonthweforeground: foreground color for week-end days belonging to the previous/next month
-
-        + othermonthwebackground: background color for week-end days belonging to the previous/next month
-
+    * Fix display of the first days of the next month
+    * Increment year when going from December to January
+    * Add widget ``DateEntry``: date selection entry with drop-down calendar
+    * Add *borderwidth*, *othermonthbackground*, *othermonthweforeground*, 
+      *othermonthwebackground* options to further customize the 
+      appearance of the calendar
 
 - tkcalendar 1.0.0
 

--- a/README.rst
+++ b/README.rst
@@ -388,25 +388,25 @@ Changelog
 
 - tkcalendar 1.3.1
 
-    * Fix bug in day selection when firstweekday is 'sunday'
+    * Fix bug in day selection when firstweekday is 'sunday' (`#28 <https://github.com/j4321/tkcalendar/issues/28>`_)
 
 - tkcalendar 1.3.0
 
-    * No longer set locale globally to avoid conflicts between several instances, use ``babel`` module instead
-    * Add *showwekknumbers* option to show/hide week numbers
-    * Add *firstweekday* option to choose first week day between 'monday' and 'sunday'
-    * Make ``DateEntry`` compatible with more ttk themes, especially OSX default theme
-    * Add possibility to display special events (like birthdays, ..) in the calendar.
+    * No longer set locale globally to avoid conflicts between several instances, use ``babel`` module instead (`#15 <https://github.com/j4321/tkcalendar/issues/15>`_)
+    * Add *showwekknumbers* option to show/hide week numbers (`#18 <https://github.com/j4321/tkcalendar/issues/18>`_)
+    * Add *firstweekday* option to choose first week day between 'monday' and 'sunday' (`#25 <https://github.com/j4321/tkcalendar/issues/25>`_)
+    * Make ``DateEntry`` compatible with more ttk themes, especially OSX default theme (`#16 <https://github.com/j4321/tkcalendar/issues/16>`_)
+    * Add possibility to display special events (like birthdays, ..) in the calendar
       The events are displayed with colors defined by tags and the event description is displayed in a tooltip
-      (see documentation).
+      (see documentation) (`#19 <https://github.com/j4321/tkcalendar/issues/19>`_)
 
 - tkcalendar 1.2.1
 
-    * Fix ``ValueError`` in ``DateEntry`` with Python 3.6.5
+    * Fix ``ValueError`` in ``DateEntry`` with Python 3.6.5 (`#13 <https://github.com/j4321/tkcalendar/issues/13>`_)
 
 - tkcalendar 1.2.0
 
-    * Add *textvariable* option to ``Calendar``
+    * Add *textvariable* option to ``Calendar`` (`#6 <https://github.com/j4321/tkcalendar/issues/6>`_)
     * Add *state* ('normal' or 'disabled') option to Calendar
     * Add *disabledselectbackground*, *disabledselectforeground*,
       *disableddaybackground* and *disableddayforeground* options to configure colors
@@ -416,12 +416,12 @@ Changelog
 
 - tkcalendar 1.1.5
 
-    * Fix endless triggering of ``<<ThemeChanged>>`` event in ``DateEntry``
+    * Fix endless triggering of ``<<ThemeChanged>>`` event in ``DateEntry`` (`#9 <https://github.com/j4321/tkcalendar/issues/9>`_)
 
 - tkcalendar 1.1.4
 
     * Fix error in January due to week 53
-    * Fix ``DateEntry`` for ttk themes other than 'clam'
+    * Fix ``DateEntry`` for ttk themes other than 'clam' (`#3 <https://github.com/j4321/tkcalendar/issues/3>`_)
 
 - tkcalendar 1.1.3
 

--- a/README.rst
+++ b/README.rst
@@ -377,7 +377,7 @@ Changelog
     * Make ``Calendar.selection_clear()`` actually clear the selection
     * Fix ``ValueError`` when retrieving default locale
     * Fix date parsing error in Swedish locale and some others (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
-    * Improve compliance with ttk themes by making the DateEntry look like a Combobox (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
+    * Improve compliance with ttk themes by making the DateEntry look like a Combobox (`#42 <https://github.com/j4321/tkcalendar/issues/42>`_)
 
 - tkcalendar 1.4.0
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,23 +6,23 @@ Changelog
 tkcalendar 1.5.0
 ----------------
 
-.. rubric:: New Calendar options
+.. rubric:: New features
+
+- :meth:`Calendar.see` method: make sure given date is visible
+
+.. rubric:: New options
 
 - *disabledforeground* and *disabledbackground*: colors of calendar border and
   month/year name in disabled state
 - *maxdate* and *mindate*: set an allowed date range for date selection
-- *weekenddays*: choose the days colored as week-end days (`#37 <https://github.com/j4321/tkcalendar/issues/37>`_).
-
-.. rubric:: New features
-
-- :meth:`Calendar.see` method: make sure given date is visible
+- *weekenddays*: choose the days colored as week-end days (`#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
 
 .. rubric:: Bug fixes
 
 - Make :meth:`Calendar.selection_clear` actually clear the selection
 - Fix :obj:`ValueError` when retrieving default locale
-- Fix date parsing error in Swedish locale and some others (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_).
-- Improve compliance with ttk themes by make the DateEntry look like a Combobox (`#42 <https://github.com/j4321/tkcalendar/issues/42>`_.)
+- Fix date parsing error in Swedish locale and some others (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
+- Improve compliance with ttk themes by make the :class:`DateEntry` look like a :class:`ttk.Combobox` (`#42 <https://github.com/j4321/tkcalendar/issues/42>`_)
 
 tkcalendar 1.4.0
 ----------------
@@ -30,15 +30,15 @@ tkcalendar 1.4.0
 .. rubric:: New features
 
 - :obj:`\<\<CalendarMonthChanged\>\>` virtual event: event generated each time the user changes the displayed month
-- :meth:`Calendar.get_displayed_month` method: return the currently displayed month in the form of a (month, year) tuple.
+- :meth:`Calendar.get_displayed_month` method: return the currently displayed month in the form of a (month, year) tuple
 
-.. rubric:: New Calendar options
+.. rubric:: New options
 
 - *showothermonthdays*: show/hide the last and first days of the previous and next months
 
 .. rubric:: Bug fixes
 
-- Fix handling of *style* option in DateEntry
+- Fix handling of *style* option in :class:`DateEntry`
 - Fix display of events for January days showing on December and conversely
 
 tkcalendar 1.3.1
@@ -51,13 +51,13 @@ tkcalendar 1.3.1
 tkcalendar 1.3.0
 ----------------
 
-.. rubric:: New feature
+.. rubric:: New features
 
 - Add possibility to display special events (like birthdays, ..) in the calendar.
   The events are displayed with colors defined by tags and the event description is displayed in a tooltip
   (see :ref:`calevent`)
 
-.. rubric:: New Calendar options
+.. rubric:: New options
 
 - *showwekknumbers*: show/hide week numbers
 - *firstweekday*: first week day ('monday' or 'sunday')
@@ -70,21 +70,20 @@ tkcalendar 1.3.0
 tkcalendar 1.2.1
 ----------------
 
-.. rubric:: Bug fix
+.. rubric:: Bug fixes
 
 - Fix :obj:`ValueError` in :class:`DateEntry` with Python 3.6.5
 
 tkcalendar 1.2.0
 ----------------
 
-.. rubric:: New Calendar options
+.. rubric:: New options
 
 - *textvariable*: connect the currently selected date to the given :class:`StringVar`
 - *state*: 'normal' or 'disabled'
 - *disabledselectbackground*, *disabledselectforeground*,
   *disableddaybackground* and *disableddayforeground*: configure colors
-  when Calendar is disabled
-
+  when :class:`Calendar` is disabled
 
 .. rubric:: Bug fixes
 
@@ -94,7 +93,7 @@ tkcalendar 1.2.0
 tkcalendar 1.1.5
 ----------------
 
-.. rubric:: Bug fix
+.. rubric:: Bug fixes
 
 - Fix endless triggering of :obj:`\<\<ThemeChanged\>\>` event in :class:`DateEntry`
 
@@ -103,7 +102,7 @@ tkcalendar 1.1.4
 
 .. rubric:: Bug fixes
 
-- Fix error in january due to week 53
+- Fix error in January due to week 53
 - Fix :class:`DateEntry` for ttk themes other than 'clam'
 
 tkcalendar 1.1.3
@@ -132,17 +131,11 @@ tkcalendar 1.1.1
 tkcalendar 1.1.0
 ----------------
 
-.. rubric:: Bug fixes
-
-- Fix display of the first days of the next month
-
-- Increment year when going from December to January
-
 .. rubric:: New widget
 
-- :class:`DateEntry`, date selection entry with drop-down calendar
+- :class:`DateEntry`: date selection entry with drop-down calendar
 
-.. rubric:: New Calendar options
+.. rubric:: New options
 
 - *borderwidth*: width of the border around the calendar (integer)
 
@@ -150,10 +143,16 @@ tkcalendar 1.1.0
 
 - *othermonthweforeground*: foreground color for week-end days belonging to the previous/next month
 
-- *othermonthwebackground*: background color for week-end days belonging to the previous/next month
+- *othermonthwebackground*: back
+
+.. rubric:: Bug fixes
+
+- Fix display of the first days of the next month
+
+- Increment year when going from December to January
 
 
 tkcalendar 1.0.0
 ----------------
 
-Initial version
+- Initial version

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ tkcalendar 1.5.0
 - *disabledforeground* and *disabledbackground*: colors of calendar border and
   month/year name in disabled state
 - *maxdate* and *mindate*: set an allowed date range for date selection
-- *weekenddays*: choose the days colored as week-end days (Fix `#37 <https://github.com/j4321/tkcalendar/issues/37>`_)
+- *weekenddays*: choose the days colored as week-end days (`#37 <https://github.com/j4321/tkcalendar/issues/37>`_).
 
 .. rubric:: New features
 
@@ -21,7 +21,8 @@ tkcalendar 1.5.0
 
 - Make :meth:`Calendar.selection_clear` actually clear the selection
 - Fix :obj:`ValueError` when retrieving default locale
-- Fix date parsing error in Swedish locale and some others. (Fix `#44 <https://github.com/j4321/tkcalendar/issues/44>`_)
+- Fix date parsing error in Swedish locale and some others (`#44 <https://github.com/j4321/tkcalendar/issues/44>`_).
+- Improve compliance with ttk themes by make the DateEntry look like a Combobox (`#42 <https://github.com/j4321/tkcalendar/issues/42>`_.)
 
 tkcalendar 1.4.0
 ----------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,7 +46,7 @@ tkcalendar 1.3.1
 
 .. rubric:: Bug fixes
 
-- Fix bug in day selection when *firstweekday* is 'sunday'
+- Fix bug in day selection when *firstweekday* is 'sunday' (`#28 <https://github.com/j4321/tkcalendar/issues/28>`_)
 
 tkcalendar 1.3.0
 ----------------
@@ -55,31 +55,31 @@ tkcalendar 1.3.0
 
 - Add possibility to display special events (like birthdays, ..) in the calendar.
   The events are displayed with colors defined by tags and the event description is displayed in a tooltip
-  (see :ref:`calevent`)
+  (see :ref:`calevent`) (`#19 <https://github.com/j4321/tkcalendar/issues/19>`_)
 
 .. rubric:: New options
 
-- *showwekknumbers*: show/hide week numbers
-- *firstweekday*: first week day ('monday' or 'sunday')
+- *showwekknumbers*: show/hide week numbers (`#18 <https://github.com/j4321/tkcalendar/issues/18>`_)
+- *firstweekday*: first week day ('monday' or 'sunday') (`#25 <https://github.com/j4321/tkcalendar/issues/25>`_)
 
 .. rubric:: Bug fixes
 
-- No longer set locale globally to avoid conflicts between several instances, use babel module instead
-- Make :class:`DateEntry` compatible with more ttk themes, especially OSX default theme
+- No longer set locale globally to avoid conflicts between several instances, use babel module instead (`#15 <https://github.com/j4321/tkcalendar/issues/15>`_)
+- Make :class:`DateEntry` compatible with more ttk themes, especially OSX default theme (`#16 <https://github.com/j4321/tkcalendar/issues/16>`_)
 
 tkcalendar 1.2.1
 ----------------
 
 .. rubric:: Bug fixes
 
-- Fix :obj:`ValueError` in :class:`DateEntry` with Python 3.6.5
+- Fix :obj:`ValueError` in :class:`DateEntry` with Python 3.6.5 (`#13 <https://github.com/j4321/tkcalendar/issues/13>`_)
 
 tkcalendar 1.2.0
 ----------------
 
 .. rubric:: New options
 
-- *textvariable*: connect the currently selected date to the given :class:`StringVar`
+- *textvariable*: connect the currently selected date to the given :class:`StringVar` (`#6 <https://github.com/j4321/tkcalendar/issues/6>`_)
 - *state*: 'normal' or 'disabled'
 - *disabledselectbackground*, *disabledselectforeground*,
   *disableddaybackground* and *disableddayforeground*: configure colors
@@ -95,7 +95,7 @@ tkcalendar 1.1.5
 
 .. rubric:: Bug fixes
 
-- Fix endless triggering of :obj:`\<\<ThemeChanged\>\>` event in :class:`DateEntry`
+- Fix endless triggering of :obj:`\<\<ThemeChanged\>\>` event in :class:`DateEntry` (`#9 <https://github.com/j4321/tkcalendar/issues/9>`_)
 
 tkcalendar 1.1.4
 ----------------
@@ -103,7 +103,7 @@ tkcalendar 1.1.4
 .. rubric:: Bug fixes
 
 - Fix error in January due to week 53
-- Fix :class:`DateEntry` for ttk themes other than 'clam'
+- Fix :class:`DateEntry` for ttk themes other than 'clam' (`#3 <https://github.com/j4321/tkcalendar/issues/3>`_)
 
 tkcalendar 1.1.3
 ----------------

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 tkcalendar - Calendar and DateEntry widgets for Tkinter
-Copyright 2017-2018 Juliette Monsel <j_4321@protonmail.com>
+Copyright 2017-2019 Juliette Monsel <j_4321@protonmail.com>
 with contributions from:
   - Neal Probert (https://github.com/nprobert)
   - arahorn28 (https://github.com/arahorn28)

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """
 tkcalendar - Calendar and DateEntry widgets for Tkinter
-Copyright 2017-2018 Juliette Monsel <j_4321@protonmail.com>
+Copyright 2017-2019 Juliette Monsel <j_4321@protonmail.com>
 with contributions from:
   - Neal Probert (https://github.com/nprobert)
   - arahorn28 (https://github.com/arahorn28)

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -99,6 +99,7 @@ class DateEntry(ttk.Entry):
         self.parse_date = self._calendar.parse_date
 
         # style
+        self._theme_name = ''   # to detect theme changes
         self.style = ttk.Style(self)
         self._setup_style()
         self.configure(style=style)
@@ -121,8 +122,6 @@ class DateEntry(ttk.Entry):
             except ValueError:
                 self._date = today
         self._set_text(self.format_date(self._date))
-
-        self._theme_change = True
 
         # --- bindings
         # reconfigure style if theme changed
@@ -149,12 +148,15 @@ class DateEntry(ttk.Entry):
         self.configure(**{key: value})
 
     def _setup_style(self, event=None):
-        """Style configuration."""
+        """Style configuration to make the DateEntry look like a Combobbox."""
         self.style.layout('DateEntry', self.style.layout('TCombobox'))
-        fieldbg = self.style.map('TCombobox', 'fieldbackground')
         self.update_idletasks()
-
-        self.style.map('DateEntry', fieldbackground=fieldbg)
+        conf = self.style.configure('TCombobox')
+        if conf:
+            self.style.configure('DateEntry', **conf)
+        maps = self.style.map('TCombobox')
+        if maps:
+            self.style.map('DateEntry', **maps)
         try:
             self.after_cancel(self._determine_downarrow_name_after_id)
         except ValueError:
@@ -163,7 +165,7 @@ class DateEntry(ttk.Entry):
         self._determine_downarrow_name_after_id = self.after(10, self._determine_downarrow_name)
 
     def _determine_downarrow_name(self, event=None):
-        """Determine downarrow button bbox."""
+        """Determine downarrow button name."""
         try:
             self.after_cancel(self._determine_downarrow_name_after_id)
         except ValueError:
@@ -192,13 +194,11 @@ class DateEntry(ttk.Entry):
                     self.configure(cursor='xterm')
 
     def _on_theme_change(self):
-        if self._theme_change:
-            self._theme_change = False
+        theme = self.style.theme_use()
+        if self._theme_name != theme:
+            # the theme has changed, update the DateEntry style to look like a combobox
+            self._theme_name = theme
             self._setup_style()
-            self.after(50, self._set_theme_change)
-
-    def _set_theme_change(self):
-        self._theme_change = True
 
     def _on_b1_press(self, event):
         """Trigger self.drop_down on downarrow button press and set widget state to ['pressed', 'active']."""


### PR DESCRIPTION
Apply the style of the `ttk.Combobox` to the `DateEntry` when the theme changes.
Improve theme change detection: `<<ThemeChanged>>` gets triggered for configuration changes as well so checked whether the theme name changed before updating the  `DateEntry` style.

Fix #42