### PR TITLE
Fix display issues in Windows and make config() method accept a dictionary of options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,7 @@ Changelog
 - tkcalendar 1.5.1
 
     * Fix calendar drop-down not in front issue if window has the ``-topmost`` attribute in Windows
+    * Make ``Calendar.config()`` and ``DateEntry.config()`` accept a dictionary like standard tkinter widgets
 
 - tkcalendar 1.5.0
 

--- a/README.rst
+++ b/README.rst
@@ -392,8 +392,9 @@ Changelog
 
 - tkcalendar 1.5.1
 
-    * Fix calendar drop-down not in front issue if window has the ``-topmost`` attribute in Windows
+    * Fix calendar drop-down not in front issue if window has the ``-topmost`` attribute in Windows (`#49 <https://github.com/j4321/tkcalendar/issues/49>`_)
     * Make ``Calendar.config()`` and ``DateEntry.config()`` accept a dictionary like standard tkinter widgets
+    * Fix calendar not hiding when clicking again on ``DateEntry`` drop-down button in Windows (`#51 <https://github.com/j4321/tkcalendar/issues/51>`_)
 
 - tkcalendar 1.5.0
 

--- a/README.rst
+++ b/README.rst
@@ -390,6 +390,10 @@ Widget methods
 Changelog
 =========
 
+- tkcalendar 1.5.1
+
+    * Fix calendar drop-down not in front issue if window has the ``-topmost`` attribute in Windows
+
 - tkcalendar 1.5.0
 
     * Add *disabledforeground* and *disabledbackground* options to further customize

--- a/docs/Calendar.rst
+++ b/docs/Calendar.rst
@@ -10,7 +10,7 @@ Class
 
 .. autoclass:: tkcalendar.Calendar
     :show-inheritance:
-    :members: calevent_cget, calevent_configure, calevent_create, calevent_lower, calevent_raise, calevent_remove, format_date, get_calevents, get_date, keys, selection_clear, selection_get, selection_set, tag_cget, tag_config, tag_delete, tag_names, get_displayed_month, see
+    :members: calevent_cget, calevent_configure, calevent_create, calevent_lower, calevent_raise, calevent_remove, configure, format_date, get_calevents, get_date, keys, selection_clear, selection_get, selection_set, tag_cget, tag_config, tag_delete, tag_names, get_displayed_month, see
 
     .. py:method:: __init__(master=None, **kw)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,14 @@ Changelog
 
 .. currentmodule:: tkcalendar
 
+tkcalendar 1.5.1
+----------------
+
+.. rubric:: Bug fixes
+
+- Fix calendar drop-down not in front issue if window has the :obj:`-topmost` attribute in Windows
+
+
 tkcalendar 1.5.0
 ----------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ tkcalendar 1.5.1
 .. rubric:: Bug fixes
 
 - Fix calendar drop-down not in front issue if window has the :obj:`-topmost` attribute in Windows
+- Make :meth:`Calendar.config` and :meth:`DateEntry.config` accept a dictionary like standard tkinter widgets
 
 
 tkcalendar 1.5.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,8 +8,9 @@ tkcalendar 1.5.1
 
 .. rubric:: Bug fixes
 
-- Fix calendar drop-down not in front issue if window has the :obj:`-topmost` attribute in Windows
+- Fix calendar drop-down not in front issue if window has the :obj:`-topmost` attribute in Windows (`#49 <https://github.com/j4321/tkcalendar/issues/49>`_)
 - Make :meth:`Calendar.config` and :meth:`DateEntry.config` accept a dictionary like standard tkinter widgets
+- Fix calendar not hiding when clicking again on :class:`DateEntry` drop-down button in Windows (`#51 <https://github.com/j4321/tkcalendar/issues/51>`_)
 
 
 tkcalendar 1.5.0

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -325,11 +325,16 @@ class TestCalendar(BaseWidgetTest):
 
         with self.assertRaises(AttributeError):
             widget.cget("test")
-
         self.assertEqual(widget["foreground"], "red")
         widget["foreground"] = "blue"
         self.window.update()
         self.assertEqual(widget["foreground"], "blue")
+        widget.configure({'foreground': 'cyan', 'background': 'green'},
+                         background="blue", borderwidth=4)
+        self.window.update()
+        self.assertEqual(widget["foreground"], "cyan")
+        self.assertEqual(widget["background"], "blue")
+        self.assertEqual(widget["borderwidth"], 4)
         widget.config(locale='fr_FR')
         self.assertEqual(widget['locale'], 'fr_FR')
         self.assertEqual(widget._week_days[0].cget('text'), 'lun.')

--- a/tests/test_dateentry.py
+++ b/tests/test_dateentry.py
@@ -74,6 +74,17 @@ class TestDateEntry(BaseWidgetTest):
         self.window.update()
         self.assertEqual(widget["borderwidth"], 5)
 
+        widget.configure({'foreground': 'cyan', 'font': 'FreeMono 10',
+                          'background': 'green'},
+                         background="blue", borderwidth=4,
+                         font="Arial 20 bold", justify='center')
+        self.window.update()
+        self.assertEqual(widget["foreground"], "cyan")
+        self.assertEqual(widget["background"], "blue")
+        self.assertEqual(widget["borderwidth"], 4)
+        self.assertEqual(widget["font"], "Arial 20 bold")
+        self.assertEqual(widget["justify"], "center")
+
         widget.config(font="Arial 20 bold")
         self.window.update()
         self.assertEqual(widget["font"], "Arial 20 bold")

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -1602,7 +1602,7 @@ class Calendar(ttk.Frame):
 
         The values for resources are specified as keyword
         arguments. To get an overview about
-        the allowed keyword arguments call the method keys.
+        the allowed keyword arguments call the method :meth:`~Calendar.keys`.
         """
         if not isinstance(cnf, dict):
             raise TypeError("Expected a dictionary or keyword arguments.")

--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -90,17 +90,17 @@ class Calendar(ttk.Frame):
             locale to use, e.g. 'en_US'
 
         date_pattern : str
-            date pattern used to format the date as a string. The default 
+            date pattern used to format the date as a string. The default
             pattern used is babel's short date format in the Calendar's locale.
 
             A valid pattern is a combination of 'y', 'm' and 'd' separated by
-            non letter characters to indicate how and in which order the 
+            non letter characters to indicate how and in which order the
             year, month and day should be displayed.
 
                 y: 'yy' for the last two digits of the year, any other number of 'y's for
                    the full year with an extra padding of zero if it has less
                    digits than the number of 'y's.
-                m: 'm' for the month number without padding, 'mm' for a 
+                m: 'm' for the month number without padding, 'mm' for a
                    two-digit month
                 d: 'd' for the day of month number without padding, 'dd' for a
                    two-digit day
@@ -1596,7 +1596,7 @@ class Calendar(ttk.Frame):
         """Return the resource value for a KEY given as string."""
         return self[key]
 
-    def configure(self, **kw):
+    def configure(self, cnf={}, **kw):
         """
         Configure resources of a widget.
 
@@ -1604,7 +1604,11 @@ class Calendar(ttk.Frame):
         arguments. To get an overview about
         the allowed keyword arguments call the method keys.
         """
-        for item, value in kw.items():
+        if not isinstance(cnf, dict):
+            raise TypeError("Expected a dictionary or keyword arguments.")
+        kwargs = cnf.copy()
+        kwargs.update(kw)
+        for item, value in kwargs.items():
             self[item] = value
 
     config = configure

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -327,7 +327,7 @@ class DateEntry(ttk.Entry):
 
         The values for resources are specified as keyword
         arguments. To get an overview about
-        the allowed keyword arguments call the method keys.
+        the allowed keyword arguments call the method :meth:`~DateEntry.keys`.
         """
         if not isinstance(cnf, dict):
             raise TypeError("Expected a dictionary or keyword arguments.")

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -321,7 +321,7 @@ class DateEntry(ttk.Entry):
         else:
             return self._calendar.cget(key)
 
-    def configure(self, **kw):
+    def configure(self, cnf={}, **kw):
         """
         Configure resources of a widget.
 
@@ -329,16 +329,21 @@ class DateEntry(ttk.Entry):
         arguments. To get an overview about
         the allowed keyword arguments call the method keys.
         """
+        if not isinstance(cnf, dict):
+            raise TypeError("Expected a dictionary or keyword arguments.")
+        kwargs = cnf.copy()
+        kwargs.update(kw)
+
         entry_kw = {}
-        keys = list(kw.keys())
+        keys = list(kwargs.keys())
         for key in keys:
             if key in self.entry_kw:
-                entry_kw[key] = kw.pop(key)
-        font = kw.get('font', None)
+                entry_kw[key] = kwargs.pop(key)
+        font = kwargs.get('font', None)
         if font is not None:
             entry_kw['font'] = font
-        ttk.Entry.configure(self, **entry_kw)
-        self._calendar.configure(**kw)
+        ttk.Entry.configure(self, entry_kw)
+        self._calendar.configure(kwargs)
         if 'date_pattern' in kw or 'locale' in kw:
             self._set_text(self.format_date(self._date))
 

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -91,6 +91,7 @@ class DateEntry(ttk.Entry):
         if platform == "linux":
             self._top_cal.attributes('-type', 'DROPDOWN_MENU')
         self._top_cal.overrideredirect(True)
+        self._top_cal.attributes('-topmost', True)
         self._calendar = Calendar(self._top_cal, **kw)
         self._calendar.pack()
 

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -220,12 +220,7 @@ class DateEntry(ttk.Entry):
                 self._top_cal.withdraw()
                 self.state(['!pressed'])
         else:
-            x, y = self._top_cal.winfo_pointerxy()
-            xc = self._top_cal.winfo_rootx()
-            yc = self._top_cal.winfo_rooty()
-            w = self._top_cal.winfo_width()
-            h = self._top_cal.winfo_height()
-            if xc <= x <= xc + w and yc <= y <= yc + h:
+            if 'active' in self.state():
                 # re-focus calendar so that <FocusOut> will be triggered next time
                 self._calendar.focus_force()
             else:


### PR DESCRIPTION
- Fix calendar drop-down not in front issue if window has the `-topmost` attribute in Windows (#49)
- Fix calendar not hiding when clicking again on `DateEntry` drop-down button (#51) in Windows
- Make `Calendar.config()` and `DateEntry.config()` accept a dictionary like standard tkinter widgets