### PR TITLE
Fix FocusOut issue with drop-down calendar when grab_set is used

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -390,6 +390,9 @@ Widget methods
 Changelog
 =========
 
+- tkcalendar 1.5.2
+    * Fix vanishing of the drop-down calendar on any click when grab_set is used 
+
 - tkcalendar 1.5.1
 
     * Fix calendar drop-down not in front issue if window has the ``-topmost`` attribute in Windows (`#49 <https://github.com/j4321/tkcalendar/issues/49>`_)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,13 @@ Changelog
 
 .. currentmodule:: tkcalendar
 
+tkcalendar 1.5.2
+----------------
+
+.. rubric:: Bug fixes
+
+- Fix vanishing of the drop-down calendar on any click when grab_set is used 
+
 tkcalendar 1.5.1
 ----------------
 

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -219,6 +219,19 @@ class DateEntry(ttk.Entry):
             else:
                 self._top_cal.withdraw()
                 self.state(['!pressed'])
+        elif self.grab_current():
+            # 'active' won't be in state because of the grab
+            x, y = self._top_cal.winfo_pointerxy()
+            xc = self._top_cal.winfo_rootx()
+            yc = self._top_cal.winfo_rooty()
+            w = self._top_cal.winfo_width()
+            h = self._top_cal.winfo_height()
+            if xc <= x <= xc + w and yc <= y <= yc + h:
+                # re-focus calendar so that <FocusOut> will be triggered next time
+                self._calendar.focus_force()
+            else:
+                self._top_cal.withdraw()
+                self.state(['!pressed'])
         else:
             if 'active' in self.state():
                 # re-focus calendar so that <FocusOut> will be triggered next time


### PR DESCRIPTION
When `grab_set()` is used, the calendar drop-down of the `DateEntry` focuses out and vanishes at any click, which prevent changing the displayed month / year. This issue is fixed by using different rules to check whether the calendar should vanish on FocusOut event when the grab is set.