### PR TITLE
optionally allow empty/whitespace values

### DIFF
--- a/tests/test_dateentry.py
+++ b/tests/test_dateentry.py
@@ -165,3 +165,17 @@ class TestDateEntry(BaseWidgetTest):
         self.window.update()
         widget._select()
         self.assertIn('readonly', widget.state())
+        
+    def test_dateentry_allow_empty(self):
+        widget = DateEntry(self.window, allow_empty=True)
+        widget.pack()
+        self.window.update()
+
+        self.assertTrue(widget._allow_empty)
+        self.assertEqual(widget.get(), '')  # should start with no value
+        widget.focus_set()
+        self.window.focus_set()
+        self.assertEqual(widget.get(), '')  # should not populate with a value
+        
+        self.assertRaises(IndexError, widget.get_date)
+        self.assertRaises(ValueError, widget.set_date, '')


### PR DESCRIPTION
# Rationale
Sometimes one might want to allow a `DateEntry` to be blank, such as when building a form.
As mentioned in #53 the behavior of automatically inserting a date on initialization / when clicking the `DateEntry` can be a little surprising,  but is [pretty easy to work around](https://github.com/j4321/tkcalendar/issues/53#issuecomment-826018340) by using the `Entry`'s `set` method.

This PR would allow one to specify this behavior by passing in an optional kwarg `allow_empty` when initializing a `DateEntry`, such that the widget would start off blank and could be left blank by deleting its contents.


# Changes
- adds `allow_empty` kwarg to `__init__`,
- adds `_allow_empty` attribute and considers it in `_validate_date`
- leaves the `Entry` blank on init if `_allow_empty == True`
- added an if clause to `drop_down` to prevent attempting to parse an empty value

empty strings and whitespace are treated equally

# Pros
- The behavior is optional and must be requested, but can easily be requested
- One can achieve the expected behavior without having to resort to adding extra buttons to a form
- `set_date` and `get_date` still complain if they find the empty value (this seems appropriate)

# Cons
- This optional behavior conflicts with [this sentiment](https://github.com/j4321/tkcalendar/issues/53#issuecomment-525180315)
> The idea is to make sure that the entry always contains a valid date when the content of the entry is retrieved.

- ~~This optional behavior isn't accounted for in the tests.~~
I'm not very familiar with writing tests, but if you have suggestions/hints I'd be happy to try to add some coverage. 