### PR TITLE
Fix January display issues #98 and #99

### DIFF
--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -963,6 +963,9 @@ class Calendar(ttk.Frame):
                     w += 1
                 if dn == 7:
                     wn += 1
+                if date.month == 1 and calendar.datetime.date(date.year,date.month,1).strftime("%A") == "Sunday":
+                    w = int(date.strftime("%U")) - 1
+                    wn = 0
             else:
                 d -= 1
             w -= wn


### PR DESCRIPTION
Fixes  issue #98 and #99
display problem occurs for any year where January 1 is a Sunday and firstweekday is set to "sunday".  fixes code by checking if the current month is January and if January 1 of the current year falls on a Sunday. If so, it sets w to the week number returned by strftime instead of isocalendar and sets wn to zero. That fixes the January problem for years where January 1 is on a Sunday and the firstweekday = 'sunday' without messing up any other months. Code fix as proposed by @jemiele1 in #99

NOTE: automatic code checks are not working and are failing in all current PR's, something is wrong with the code check environments unrelated to this and the other PRs.
Test failures are due to ERROR: test_calendar_textvariable (tests.test_calendar.TestCalendar) from ```tkcalendar\tests\test_calendar.py", line 228, in test_calendar_textvariable
    year=2015, month=1, day=3, textvariable=var)```
 which causes
```
babel\dates.py", line 1201, in parse_date raise ParseError("No numbers were found in input")
babel.dates.ParseError: No numbers were found in input
```

This build error only occurs in the python 3.6 and 3.7 builds and should be addressed outside of this PR