### PR TITLE
Fixed issue #72: Fixed left and right month arrows when min and max dates are defined

### DIFF
--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -1094,7 +1094,7 @@ class Calendar(ttk.Frame):
                     self._r_year.state(['disabled'])
                 else:
                     self._r_year.state(['!disabled'])
-                    self._r_month.state(['!disabled'])
+                self._r_month.state(['!disabled'])
             else:  # dy > 1
                 self._r_year.state(['!disabled'])
                 self._r_month.state(['!disabled'])
@@ -1115,9 +1115,9 @@ class Calendar(ttk.Frame):
             elif dy == 1:
                 if self._date.month >= min_month:
                     self._l_year.state(['!disabled'])
-                    self._l_month.state(['!disabled'])
                 else:
                     self._l_year.state(['disabled'])
+                self._l_month.state(['!disabled'])
             else:  # dy > 1
                 self._l_year.state(['!disabled'])
                 self._l_month.state(['!disabled'])


### PR DESCRIPTION
Fixed Issue #72.

When min_date or max_date were defined, the left and right month arrows were sometimes incorrectly disabled.
Solution proposed by @kofflo was implemented for left and right arrows. Works as expected.
