### PR TITLE
Avoid creating style on every <<ThemeChanged>> event.

### DIFF
--- a/tkcalendar/calendar_.py
+++ b/tkcalendar/calendar_.py
@@ -492,10 +492,13 @@ class Calendar(ttk.Frame):
 
         self.config(state=state)
 
-        # --- bindings
-        self.bind('<<ThemeChanged>>', self._setup_style)
-
+        self._theme_name = None
         self._setup_style()
+
+        # --- bindings
+        self.theme_change_cbid = None
+        self.bind('<<ThemeChanged>>', self.schedule_style_update)
+
         self._display_calendar()
         self._btns_date_range()
         self._check_sel_date()
@@ -746,6 +749,18 @@ class Calendar(ttk.Frame):
                     self._display_calendar()
                     self._display_selection()
 
+    def schedule_style_update(self, event=None):
+        if self.theme_change_cbid is None:
+            self.theme_change_cbid = self.after(10, self._on_theme_change)
+
+    def _on_theme_change(self):
+        theme = self.style.theme_use()
+        if self._theme_name != theme:
+            # the theme has changed, update the DateEntry style to look like a combobox
+            self._theme_name = theme
+            self._setup_style()
+        self.theme_change_cbid = None
+
     def _setup_style(self, event=None):
         """Configure style."""
         self.style.layout('L.%s.TButton' % self._style_prefixe,
@@ -819,6 +834,7 @@ class Calendar(ttk.Frame):
         self.style.map(self._style_prefixe + '.TLabel',
                        background=[('disabled', dis_day_bg)],
                        foreground=[('disabled', dis_day_fg)])
+        self._theme_name = self.style.theme_use()
 
     # --- display
     def _display_calendar(self):

--- a/tkcalendar/dateentry.py
+++ b/tkcalendar/dateentry.py
@@ -159,8 +159,8 @@ class DateEntry(ttk.Entry):
 
         # --- bindings
         # reconfigure style if theme changed
-        self.bind('<<ThemeChanged>>',
-                  lambda e: self.after(10, self._on_theme_change))
+        self.theme_change_cbid = None
+        self.bind('<<ThemeChanged>>', self.schedule_style_update)
         # determine new downarrow button bbox
         self.bind('<Configure>', self._determine_downarrow_name)
         self.bind('<Map>', self._determine_downarrow_name)
@@ -180,6 +180,10 @@ class DateEntry(ttk.Entry):
 
     def __setitem__(self, key, value):
         self.configure(**{key: value})
+
+    def schedule_style_update(self, event=None):
+        if self.theme_change_cbid is None:
+            self.theme_change_cbid = self.after(10, self._on_theme_change)
 
     def _setup_style(self, event=None):
         """Style configuration to make the DateEntry look like a Combobbox."""
@@ -202,6 +206,7 @@ class DateEntry(ttk.Entry):
             # nothing to cancel
             pass
         self._determine_downarrow_name_after_id = self.after(10, self._determine_downarrow_name)
+        self._theme_name = self.style.theme_use()
 
     def _determine_downarrow_name(self, event=None):
         """Determine downarrow button name."""
@@ -237,6 +242,7 @@ class DateEntry(ttk.Entry):
             # the theme has changed, update the DateEntry style to look like a combobox
             self._theme_name = theme
             self._setup_style()
+        self.theme_change_cbid = None
 
     def _on_b1_press(self, event):
         """Trigger self.drop_down on downarrow button press and set widget state to ['pressed', 'active']."""


### PR DESCRIPTION
When a \<\<ThemeChanged>> occurs the style is recreated again.
This can slow down ui update if you have multiple DateEntry widgets and you change the style of another widget.

The following script tries to show how the style is re-created if I modify the style of another widget.

```python
#!/usr/bin/python3
import tkinter as tk
import tkinter.ttk as ttk
from tkcalendar import Calendar as CalendarBase
from tkcalendar import DateEntry as DateEntryBase


class Calendar(CalendarBase):
    def _setup_style(self, event=None):
        print("Calendar: _setup_style() called for", self)
        super()._setup_style(event)


class DateEntry(DateEntryBase):
    def _setup_style(self, event=None):
        print("DateEntry: _setup_style() called for", self)
        super()._setup_style(event)  



class ThemeIssueDemoUI:
    def __init__(self, master=None, data_pool=None):
        # build ui
        tk1 = tk.Tk(master)
        tk1.configure(height=200, width=200)
        frame2 = ttk.Frame(tk1)
        frame2.configure(height=200, padding=5, width=200)
        frame3 = ttk.Frame(frame2)
        frame3.configure(height=200, width=200)
        label2 = ttk.Label(frame3)
        label2.configure(
            font="{Helvetica} 16 {}",
            style="Colored.TLabel",
            text='Colored Label')
        label2.pack(pady=40, side="top")
        button1 = ttk.Button(frame3)
        button1.configure(text='Change label color')
        button1.pack(side="top")
        button1.configure(command=self.on_change_label_color)
        frame3.pack(expand=True, side="bottom")
        label1 = ttk.Label(frame2)
        label1.configure(text='Theme:')
        label1.pack(side="left")
        self.cb_theme = ttk.Combobox(frame2, name="cb_theme")
        self.theme_var = tk.StringVar()
        self.cb_theme.configure(textvariable=self.theme_var)
        self.cb_theme.pack(side="left")
        self.cb_theme.bind(
            "<<ComboboxSelected>>",
            self.on_theme_changed,
            add="")
        frame2.pack(expand=True, fill="both", side="left")
        frame1 = ttk.Frame(tk1)
        frame1.configure(height=200, padding=5, width=200)
        calendar1 = Calendar(frame1)
        calendar1.pack(side="top")
        dateentry1 = DateEntry(frame1)
        dateentry1.pack(side="top")
        frame1.pack(side="left")

        # Main widget
        self.mainwindow = tk1

    def run(self):
        self.mainwindow.mainloop()

    def on_change_label_color(self):
        pass

    def on_theme_changed(self, event=None):
        pass


class ThemeIssueDemo(ThemeIssueDemoUI):
    def __init__(self, master=None):
        super().__init__(master)
        
        self.style = ttk.Style(self.mainwindow)
        themes = self.style.theme_names()
        self.cb_theme.configure(values=themes)
        self.theme_var.set(self.style.theme_use())
    
    def on_theme_changed(self, event=None):
        value = self.cb_theme.get()
        print(f"Using theme {value}")
        self.style.theme_use(value)    

    def on_change_label_color(self):
        print("Label color change.")
        self.style.configure("Colored.TLabel", foreground="green")


if __name__ == "__main__":
    app = ThemeIssueDemo()
    app.run()
```
